### PR TITLE
Implement UniquePtr

### DIFF
--- a/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
+++ b/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
@@ -94,7 +94,7 @@ public:
   inline UniquePtr(UniquePtr<U, E> &&r_ptr) : ptr_(r_ptr.release()),
       d_(std::forward<E>(r_ptr.get_deleter())) { }
 
-  UniquePtr<T>& operator=(UniquePtr &&r_ptr) {
+  UniquePtr& operator=(UniquePtr &&r_ptr) {
     reset(r_ptr.release());
     get_deleter() = std::forward<Deleter>(r_ptr.get_deleter());
     return *this;

--- a/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
+++ b/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
@@ -99,14 +99,14 @@ private:
 
 template<class T, class Deleter=std::default_delete<T>>
 inline
-UniquePtr<T>
+UniquePtr<T, Deleter>
 uniqueptr(T* p)
 {
   return UniquePtr<T>(p);
 }
 
 template<class T2, class T1, class Deleter=std::default_delete<T1>>
-Ptr<T2> uniqueptr_implicit_cast(const UniquePtr<T1>& p1)
+Ptr<T2> uniqueptr_implicit_cast(const UniquePtr<T1, Deleter>& p1)
 {
   return Ptr<T2>(p1.get()); // Will only compile if conversion is legal!
 }
@@ -114,49 +114,49 @@ Ptr<T2> uniqueptr_implicit_cast(const UniquePtr<T1>& p1)
 // --------------------------------
 // Implementation of UniquePtr
 
-template<class T, class Deleter=std::default_delete<T>>
+template<class T, class Deleter>
 UniquePtr<T, Deleter>::UniquePtr( ENull /*null_in*/ )
   : ptr_(0)
 {}
 
-template<class T, class Deleter=std::default_delete<T>>
-UniquePtr<T>::~UniquePtr()
+template<class T, class Deleter>
+UniquePtr<T, Deleter>::~UniquePtr()
 {
 #ifndef TEUCHOS_DEBUG
   delete ptr_.get(); // Note: the pointer can be null
 #endif
 }
 
-template<class T, class Deleter=std::default_delete<T>>
+template<class T, class Deleter>
 inline
-const Ptr<T> UniquePtr<T>::ptr() const {
+const Ptr<T> UniquePtr<T, Deleter>::ptr() const {
   return ptr_.ptr();
 }
 
-template<class T, class Deleter=std::default_delete<T>>
+template<class T, class Deleter>
 inline
-T* UniquePtr<T>::get() const
+T* UniquePtr<T, Deleter>::get() const
 {
   return ptr_.get();
 }
 
-template<class T, class Deleter=std::default_delete<T>>
+template<class T, class Deleter>
 inline
-T* UniquePtr<T>::getRawPtr() const
+T* UniquePtr<T, Deleter>::getRawPtr() const
 {
   return get();
 }
 
-template<class T, class Deleter=std::default_delete<T>>
+template<class T, class Deleter>
 inline
-Ptr<const T> UniquePtr<T>::getConst() const
+Ptr<const T> UniquePtr<T, Deleter>::getConst() const
 {
   return uniqueptr_implicit_cast<const T>(*this);
 }
 
-template<class T, class Deleter=std::default_delete<T>>
+template<class T, class Deleter>
 inline
-void UniquePtr<T>::reset()
+void UniquePtr<T, Deleter>::reset()
 {
 #ifdef TEUCHOS_DEBUG
   ptr_.reset();
@@ -176,7 +176,7 @@ void UniquePtr<T>::reset()
  */
 template<class T, class Deleter=std::default_delete<T>>
 inline
-bool is_null( const UniquePtr<T> &p )
+bool is_null( const UniquePtr<T, Deleter> &p )
 {
   return p.get() == 0;
 }
@@ -187,7 +187,7 @@ bool is_null( const UniquePtr<T> &p )
  */
 template<class T, class Deleter=std::default_delete<T>>
 inline
-bool nonnull( const UniquePtr<T> &p )
+bool nonnull( const UniquePtr<T, Deleter> &p )
 {
   return p.get() != 0;
 }

--- a/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
+++ b/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
@@ -76,6 +76,9 @@ public:
   inline T* getRawPtr() const;
 
 //  inline const Ptr<T> ptr() const;
+
+  /** \brief Return a Ptr<const T> version of *this. */
+  inline Ptr<const T> getConst() const;
 private:
 #ifdef TEUCHOS_DEBUG
   RCP<T> ptr_;
@@ -83,6 +86,12 @@ private:
   Ptr<T> ptr_;
 #endif
 };
+
+template<class T2, class T1>
+Ptr<T2> uniqueptr_implicit_cast(const UniquePtr<T1>& p1)
+{
+  return Ptr<T2>(p1.get()); // Will only compile if conversion is legal!
+}
 
 template<class T> inline
 UniquePtr<T>::UniquePtr( ENull /*null_in*/ )
@@ -115,6 +124,16 @@ T* UniquePtr<T>::getRawPtr() const
 {
   return get();
 }
+
+template<class T> inline
+Ptr<const T> UniquePtr<T>::getConst() const
+{
+  return uniqueptr_implicit_cast<const T>(*this);
+}
+
+//------------------------------------------------------
+// Non member functions
+
 
 /** \brief Returns true if <tt>p.get()==NULL</tt>.
  *

--- a/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
+++ b/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
@@ -56,9 +56,7 @@ template<class T>
 class UniquePtr {
 public:
   inline UniquePtr( ENull null_in = null );
-  inline explicit UniquePtr( T *ptr_in ) : ptr_(ptr_in) {
-//        ASSERT(ptr != nullptr)
-  }
+  inline explicit UniquePtr( T *ptr_in ) : ptr_(ptr_in) { }
   ~UniquePtr();
   // Copy constructor and assignment are disabled
   inline UniquePtr(const UniquePtr<T>& ptr) = delete;

--- a/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
+++ b/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
@@ -71,8 +71,8 @@ public:
     std::swap(ptr_, r_ptr.ptr_);
     return *this;
   }
-  inline T* operator->() const { return ptr_.get(); }
-  inline T& operator*() const { return *ptr_; }
+  inline T* operator->() const { return ptr_.operator->(); }
+  inline T& operator*() const { return ptr_.operator*(); }
 
   /** \brief Get the raw C++ pointer to the underlying object. */
   inline T* get() const;

--- a/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
+++ b/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
@@ -60,7 +60,7 @@ public:
 //        ASSERT(ptr != nullptr)
     }
 #ifndef TEUCHOS_DEBUG
-    ~UniquePtr() { delete ptr_; }
+    ~UniquePtr() { delete ptr_.get(); }
 #endif
     // Copy constructor and assignment are disabled
     inline UniquePtr(const UniquePtr<T>& ptr) = delete;
@@ -79,7 +79,7 @@ private:
 #ifdef TEUCHOS_DEBUG
     RCP<T> ptr_;
 #else
-    T *ptr_;
+    Ptr<T> ptr_;
 #endif
 };
 
@@ -90,21 +90,13 @@ UniquePtr<T>::UniquePtr( ENull /*null_in*/ )
 
 template<class T> inline
 const Ptr<T> UniquePtr<T>::ptr() const {
-#ifdef TEUCHOS_DEBUG
     return ptr_.ptr();
-#else
-    return Ptr<T>(ptr_);
-#endif
 }
 
 template<class T> inline
 T* UniquePtr<T>::get() const
 {
-#ifdef TEUCHOS_DEBUG
     return ptr_.get();
-#else
-    return ptr_;
-#endif
 }
 
 /** \brief Returns true if <tt>p.get()==NULL</tt>.

--- a/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
+++ b/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
@@ -171,6 +171,29 @@ Ptr<T2> uniqueptr_implicit_cast(const UniquePtr<T1, Deleter>& p1)
   return Ptr<T2>(p1.get()); // Will only compile if conversion is legal!
 }
 
+/** \brief Returns true if <tt>p.get()==NULL</tt>.
+ *
+ * \relates UniquePtr
+ */
+template<class T, class Deleter=std::default_delete<T>>
+inline
+bool is_null( const UniquePtr<T, Deleter> &p )
+{
+  return !bool(p);
+}
+
+/** \brief Returns true if <tt>p.get()!=NULL</tt>
+ *
+ * \relates UniquePtr
+ */
+template<class T, class Deleter=std::default_delete<T>>
+inline
+bool nonnull( const UniquePtr<T, Deleter> &p )
+{
+  return bool(p);
+}
+
+
 // --------------------------------
 // Implementation of UniquePtr
 
@@ -346,31 +369,6 @@ void UniquePtr<T, Deleter>::reset(T *r_ptr)
 #endif
 }
 
-//------------------------------------------------------
-// Non member functions
-
-
-/** \brief Returns true if <tt>p.get()==NULL</tt>.
- *
- * \relates UniquePtr
- */
-template<class T, class Deleter=std::default_delete<T>>
-inline
-bool is_null( const UniquePtr<T, Deleter> &p )
-{
-  return !bool(p);
-}
-
-/** \brief Returns true if <tt>p.get()!=NULL</tt>
- *
- * \relates UniquePtr
- */
-template<class T, class Deleter=std::default_delete<T>>
-inline
-bool nonnull( const UniquePtr<T, Deleter> &p )
-{
-  return bool(p);
-}
 
 #endif // HAVE_TEUCHOSCORE_CXX11
 

--- a/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
+++ b/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
@@ -124,10 +124,13 @@ public:
    */
 
   /** \brief Return a Ptr<T> version of *this. */
-  inline const Ptr<T> ptr() const;
+  inline Ptr<T> ptr() const;
 
   /** \brief Return a Ptr<const T> version of *this. */
   inline Ptr<const T> getConst() const;
+
+  /** \brief Shorthand for ptr(). */
+  inline Ptr<T> operator()() const;
 
   /*
    *                   Teuchos compatibility methods
@@ -136,6 +139,8 @@ public:
   /** \brief Get the raw C++ pointer to the underlying object. */
   inline T* getRawPtr() const;
 
+  /** \brief Returns true if the underlying pointer is null. */
+  inline bool is_null() const;
 
 private:
   typedef
@@ -221,8 +226,16 @@ inline UniquePtr<T, Deleter>::UniquePtr(UniquePtr<U, E> &&r_ptr)
 
 template<class T, class Deleter>
 inline
-const Ptr<T> UniquePtr<T, Deleter>::ptr() const {
+Ptr<T> UniquePtr<T, Deleter>::ptr() const
+{
   return std::get<0>(t_).ptr();
+}
+
+template<class T, class Deleter>
+inline
+Ptr<T> UniquePtr<T, Deleter>::operator()() const
+{
+  return ptr();
 }
 
 template<class T, class Deleter>
@@ -284,6 +297,12 @@ inline
 UniquePtr<T, Deleter>::operator bool() const
 {
   return get() != nullptr;
+}
+
+template<class T, class Deleter>
+inline bool UniquePtr<T, Deleter>::is_null() const
+{
+  return get() == nullptr;
 }
 
 template<class T, class Deleter>

--- a/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
+++ b/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
@@ -117,6 +117,16 @@ bool is_null( const UniquePtr<T> &p )
     return p.get() == 0;
 }
 
+/** \brief Returns true if <tt>p.get()!=NULL</tt>
+ *
+ * \relates UniquePtr
+ */
+template<class T> inline
+bool nonnull( const UniquePtr<T> &p )
+{
+  return p.get() != 0;
+}
+
 #endif // HAVE_TEUCHOSCORE_CXX11
 
 

--- a/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
+++ b/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
@@ -72,9 +72,7 @@ public:
     r_ptr.ptr_ = null;
   }
   template<class U, class E>
-  inline UniquePtr(UniquePtr<U, E> &&r_ptr) : ptr_(r_ptr.get_ptr_()) {
-    r_ptr.set_ptr_null_();
-  }
+  inline UniquePtr(UniquePtr<U, E> &&r_ptr) : ptr_(r_ptr.release()) { }
   UniquePtr<T>& operator=(UniquePtr &&r_ptr) {
     std::swap(ptr_, r_ptr.ptr_);
     return *this;
@@ -104,19 +102,6 @@ public:
 #endif
     ptr_ = null;
     return p;
-  }
-
-  // FIXME: DO NOT USE THESE
-#ifdef TEUCHOS_DEBUG
-  inline RCP<T> get_ptr_() {
-#else
-  inline Ptr<T> get_ptr_() {
-#endif
-    return ptr_;
-  }
-
-  inline void set_ptr_null_() {
-    ptr_ = null;
   }
 private:
 #ifdef TEUCHOS_DEBUG

--- a/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
+++ b/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
@@ -88,9 +88,12 @@ public:
 
   // Move constructor and assignment
   inline UniquePtr(UniquePtr &&r_ptr) : ptr_(r_ptr.release()),
-      d_(std::forward<Deleter>(r_ptr.d_)) { }
+      d_(std::forward<Deleter>(r_ptr.get_deleter())) { }
+
   template<class U, class E>
-  inline UniquePtr(UniquePtr<U, E> &&r_ptr) : ptr_(r_ptr.release()) { }
+  inline UniquePtr(UniquePtr<U, E> &&r_ptr) : ptr_(r_ptr.release()),
+      d_(std::forward<E>(r_ptr.get_deleter())) { }
+
   UniquePtr<T>& operator=(UniquePtr &&r_ptr) {
     std::swap(ptr_, r_ptr.ptr_);
     return *this;
@@ -121,6 +124,15 @@ public:
     ptr_ = null;
     return p;
   }
+
+  Deleter& get_deleter() noexcept {
+    return d_;
+  }
+
+  const Deleter& get_deleter() const noexcept {
+    return d_;
+  }
+
 private:
 #ifdef TEUCHOS_DEBUG
   RCP<T> ptr_;

--- a/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
+++ b/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
@@ -94,18 +94,10 @@ public:
   inline UniquePtr(UniquePtr<U, E> &&r_ptr) : ptr_(r_ptr.release()),
       d_(std::forward<E>(r_ptr.get_deleter())) { }
 
-  UniquePtr& operator=(UniquePtr &&r_ptr) {
-    reset(r_ptr.release());
-    get_deleter() = std::forward<Deleter>(r_ptr.get_deleter());
-    return *this;
-  }
+  inline UniquePtr& operator=(UniquePtr &&r_ptr);
 
   template<class U, class E>
-  UniquePtr& operator=(UniquePtr<U, E> &&r_ptr) {
-    reset(r_ptr.release());
-    get_deleter() = std::forward<E>(r_ptr.get_deleter());
-    return *this;
-  }
+  inline UniquePtr& operator=(UniquePtr<U, E> &&r_ptr);
 
 
   /*
@@ -217,6 +209,22 @@ template<class T, class Deleter>
 inline
 const Ptr<T> UniquePtr<T, Deleter>::ptr() const {
   return ptr_.ptr();
+}
+
+template<class T, class Deleter>
+inline
+UniquePtr<T, Deleter>& UniquePtr<T, Deleter>::operator=(UniquePtr<T, Deleter> &&r_ptr) {
+  reset(r_ptr.release());
+  get_deleter() = std::forward<Deleter>(r_ptr.get_deleter());
+  return *this;
+}
+
+template<class T, class Deleter>
+template<class U, class E>
+inline UniquePtr<T, Deleter>& UniquePtr<T, Deleter>::operator=(UniquePtr<U, E> &&r_ptr) {
+  reset(r_ptr.release());
+  get_deleter() = std::forward<E>(r_ptr.get_deleter());
+  return *this;
 }
 
 template<class T, class Deleter>

--- a/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
+++ b/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
@@ -68,9 +68,7 @@ public:
   inline UniquePtr(const UniquePtr<T>& ptr) = delete;
   UniquePtr<T>& operator=(const UniquePtr<T>& ptr) = delete;
   // Move constructor and assignment
-  inline UniquePtr(UniquePtr &&r_ptr) : ptr_(r_ptr.ptr_) {
-    r_ptr.ptr_ = null;
-  }
+  inline UniquePtr(UniquePtr &&r_ptr) : ptr_(r_ptr.release()) { }
   template<class U, class E>
   inline UniquePtr(UniquePtr<U, E> &&r_ptr) : ptr_(r_ptr.release()) { }
   UniquePtr<T>& operator=(UniquePtr &&r_ptr) {

--- a/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
+++ b/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
@@ -125,7 +125,7 @@ template<class T>
 UniquePtr<T>::~UniquePtr()
 {
 #ifndef TEUCHOS_DEBUG
-  delete ptr_.get();
+  delete ptr_.get(); // Note: the pointer can be null
 #endif
 }
 
@@ -158,7 +158,7 @@ void UniquePtr<T>::reset()
 #ifdef TEUCHOS_DEBUG
   ptr_.reset();
 #else
-  delete ptr_.get();
+  delete ptr_.get(); // Note: the pointer can be null
   ptr_ = null;
 #endif
 }

--- a/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
+++ b/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
@@ -57,6 +57,12 @@ class UniquePtr {
 public:
   inline UniquePtr( ENull null_in = null );
   inline explicit UniquePtr( T *ptr_in ) : ptr_(ptr_in) { }
+  inline explicit UniquePtr( T *ptr_in, const Deleter &d)
+      : ptr_(ptr_in
+#ifdef TEUCHOS_DEBUG
+          , deallocFunctorDelete<T, Deleter>(d), true
+#endif
+          ), d_(d) { }
   ~UniquePtr();
   // Copy constructor and assignment are disabled
   inline UniquePtr(const UniquePtr<T>& ptr) = delete;
@@ -92,6 +98,7 @@ private:
 #else
   Ptr<T> ptr_;
 #endif
+  Deleter d_;
 };
 
 // -------------------------
@@ -123,7 +130,7 @@ template<class T, class Deleter>
 UniquePtr<T, Deleter>::~UniquePtr()
 {
 #ifndef TEUCHOS_DEBUG
-  delete ptr_.get(); // Note: the pointer can be null
+  d_(ptr_.get()); // Note: the pointer can be null
 #endif
 }
 
@@ -161,7 +168,7 @@ void UniquePtr<T, Deleter>::reset()
 #ifdef TEUCHOS_DEBUG
   ptr_.reset();
 #else
-  delete ptr_.get(); // Note: the pointer can be null
+  d_(ptr_.get()); // Note: the pointer can be null
   ptr_ = null;
 #endif
 }

--- a/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
+++ b/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
@@ -107,20 +107,10 @@ public:
     return *this;
   }
 
-  inline T* operator->() const { return ptr_.operator->(); }
-  inline T& operator*() const { return ptr_.operator*(); }
 
-  /** \brief Get the raw C++ pointer to the underlying object. */
-  inline T* get() const;
-
-  /** \brief Get the raw C++ pointer to the underlying object. */
-  inline T* getRawPtr() const;
-
-  /** \brief Return a Ptr<T> version of *this. */
-  inline const Ptr<T> ptr() const;
-
-  /** \brief Return a Ptr<const T> version of *this. */
-  inline Ptr<const T> getConst() const;
+  /*
+   *                   Modifiers
+   */
 
   inline T* release() {
     T *p = get();
@@ -139,6 +129,13 @@ public:
     std::swap(get_deleter(), other.get_deleter());
   }
 
+  /*
+   *                   Observers
+   */
+
+  /** \brief Get the raw C++ pointer to the underlying object. */
+  inline T* get() const;
+
   Deleter& get_deleter() noexcept {
     return d_;
   }
@@ -146,6 +143,33 @@ public:
   const Deleter& get_deleter() const noexcept {
     return d_;
   }
+
+  // FIXME: operator bool
+
+  /*
+   *                   Dereferencing
+   */
+
+  inline T* operator->() const { return ptr_.operator->(); }
+  inline T& operator*() const { return ptr_.operator*(); }
+
+  /*
+   *                   Observers Ptr
+   */
+
+  /** \brief Return a Ptr<T> version of *this. */
+  inline const Ptr<T> ptr() const;
+
+  /** \brief Return a Ptr<const T> version of *this. */
+  inline Ptr<const T> getConst() const;
+
+  /*
+   *                   Teuchos compatibility methods
+   */
+
+  /** \brief Get the raw C++ pointer to the underlying object. */
+  inline T* getRawPtr() const;
+
 
 private:
 #ifdef TEUCHOS_DEBUG

--- a/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
+++ b/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
@@ -1,0 +1,93 @@
+// @HEADER
+// ***********************************************************************
+//
+//                    Teuchos: Common Tools Package
+//                 Copyright (2004) Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ***********************************************************************
+// @HEADER
+
+
+#ifndef TEUCHOS_UNIQUEPTR_HPP
+#define TEUCHOS_UNIQUEPTR_HPP
+
+
+#include "Teuchos_PtrDecl.hpp"
+#include "Teuchos_RCP.hpp"
+
+
+namespace Teuchos {
+
+#ifdef HAVE_TEUCHOSCORE_CXX11
+
+template<class T>
+class UniquePtr {
+public:
+    inline explicit UniquePtr( T *ptr ) : ptr_(ptr) {
+//        ASSERT(ptr != nullptr)
+    }
+#ifndef TEUCHOS_DEBUG
+    ~UniquePtr() { delete ptr_; }
+#endif
+    // Copy constructor and assignment are disabled
+    inline UniquePtr(const UniquePtr<T>& ptr) = delete;
+    UniquePtr<T>& operator=(const UniquePtr<T>& ptr) = delete;
+    // Move constructor and assignment
+    inline UniquePtr(UniquePtr&&) = delete;
+    UniquePtr<T>& operator=(UniquePtr&&) = delete;
+    inline T* operator->() const { return ptr_; }
+    inline T& operator*() const { return *ptr_; }
+    inline const Ptr<T> ptr() const {
+#ifdef TEUCHOS_DEBUG
+        return ptr_.ptr();
+#else
+        return Ptr<T>(ptr_);
+#endif
+    }
+private:
+#ifdef TEUCHOS_DEBUG
+    RCP<T> ptr_;
+#else
+    T *ptr_;
+#endif
+};
+
+
+#endif
+
+
+} // namespace Teuchos
+
+#endif // TEUCHOS_PTR_HPP

--- a/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
+++ b/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
@@ -52,7 +52,7 @@ namespace Teuchos {
 
 #ifdef HAVE_TEUCHOSCORE_CXX11
 
-template<class T>
+template<class T, class Deleter=std::default_delete<T>>
 class UniquePtr {
 public:
   inline UniquePtr( ENull null_in = null );
@@ -97,7 +97,7 @@ private:
 // -------------------------
 // Non member functions
 
-template<class T>
+template<class T, class Deleter=std::default_delete<T>>
 inline
 UniquePtr<T>
 uniqueptr(T* p)
@@ -105,7 +105,7 @@ uniqueptr(T* p)
   return UniquePtr<T>(p);
 }
 
-template<class T2, class T1>
+template<class T2, class T1, class Deleter=std::default_delete<T1>>
 Ptr<T2> uniqueptr_implicit_cast(const UniquePtr<T1>& p1)
 {
   return Ptr<T2>(p1.get()); // Will only compile if conversion is legal!
@@ -114,12 +114,12 @@ Ptr<T2> uniqueptr_implicit_cast(const UniquePtr<T1>& p1)
 // --------------------------------
 // Implementation of UniquePtr
 
-template<class T> inline
-UniquePtr<T>::UniquePtr( ENull /*null_in*/ )
+template<class T, class Deleter=std::default_delete<T>>
+UniquePtr<T, Deleter>::UniquePtr( ENull /*null_in*/ )
   : ptr_(0)
 {}
 
-template<class T>
+template<class T, class Deleter=std::default_delete<T>>
 UniquePtr<T>::~UniquePtr()
 {
 #ifndef TEUCHOS_DEBUG
@@ -127,30 +127,35 @@ UniquePtr<T>::~UniquePtr()
 #endif
 }
 
-template<class T> inline
+template<class T, class Deleter=std::default_delete<T>>
+inline
 const Ptr<T> UniquePtr<T>::ptr() const {
   return ptr_.ptr();
 }
 
-template<class T> inline
+template<class T, class Deleter=std::default_delete<T>>
+inline
 T* UniquePtr<T>::get() const
 {
   return ptr_.get();
 }
 
-template<class T> inline
+template<class T, class Deleter=std::default_delete<T>>
+inline
 T* UniquePtr<T>::getRawPtr() const
 {
   return get();
 }
 
-template<class T> inline
+template<class T, class Deleter=std::default_delete<T>>
+inline
 Ptr<const T> UniquePtr<T>::getConst() const
 {
   return uniqueptr_implicit_cast<const T>(*this);
 }
 
-template<class T> inline
+template<class T, class Deleter=std::default_delete<T>>
+inline
 void UniquePtr<T>::reset()
 {
 #ifdef TEUCHOS_DEBUG
@@ -169,7 +174,8 @@ void UniquePtr<T>::reset()
  *
  * \relates UniquePtr
  */
-template<class T> inline
+template<class T, class Deleter=std::default_delete<T>>
+inline
 bool is_null( const UniquePtr<T> &p )
 {
   return p.get() == 0;
@@ -179,7 +185,8 @@ bool is_null( const UniquePtr<T> &p )
  *
  * \relates UniquePtr
  */
-template<class T> inline
+template<class T, class Deleter=std::default_delete<T>>
+inline
 bool nonnull( const UniquePtr<T> &p )
 {
   return p.get() != 0;

--- a/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
+++ b/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
@@ -95,7 +95,8 @@ public:
       d_(std::forward<E>(r_ptr.get_deleter())) { }
 
   UniquePtr<T>& operator=(UniquePtr &&r_ptr) {
-    std::swap(ptr_, r_ptr.ptr_);
+    reset(r_ptr.release());
+    get_deleter() = std::forward<Deleter>(r_ptr.get_deleter());
     return *this;
   }
   inline T* operator->() const { return ptr_.operator->(); }
@@ -114,7 +115,7 @@ public:
   inline Ptr<const T> getConst() const;
 
   /** \brief Reset to null. */
-  inline void reset();
+  inline void reset(T *r_ptr=nullptr);
 
   inline T* release() {
     T *p = get();
@@ -204,13 +205,14 @@ Ptr<const T> UniquePtr<T, Deleter>::getConst() const
 
 template<class T, class Deleter>
 inline
-void UniquePtr<T, Deleter>::reset()
+void UniquePtr<T, Deleter>::reset(T *r_ptr)
 {
 #ifdef TEUCHOS_DEBUG
   ptr_.reset();
+  ptr_ = rcp(r_ptr);
 #else
   d_(ptr_.get()); // Note: the pointer can be null
-  ptr_ = null;
+  ptr_ = Ptr<T>(r_ptr);
 #endif
 }
 

--- a/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
+++ b/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
@@ -75,7 +75,8 @@ public:
   /** \brief Get the raw C++ pointer to the underlying object. */
   inline T* getRawPtr() const;
 
-//  inline const Ptr<T> ptr() const;
+  /** \brief Return a Ptr<T> version of *this. */
+  inline const Ptr<T> ptr() const;
 
   /** \brief Return a Ptr<const T> version of *this. */
   inline Ptr<const T> getConst() const;
@@ -87,11 +88,25 @@ private:
 #endif
 };
 
+// -------------------------
+// Non member functions
+
+template<class T>
+inline
+UniquePtr<T>
+uniqueptr(T* p)
+{
+  return UniquePtr<T>(p);
+}
+
 template<class T2, class T1>
 Ptr<T2> uniqueptr_implicit_cast(const UniquePtr<T1>& p1)
 {
   return Ptr<T2>(p1.get()); // Will only compile if conversion is legal!
 }
+
+// --------------------------------
+// Implementation of UniquePtr
 
 template<class T> inline
 UniquePtr<T>::UniquePtr( ENull /*null_in*/ )
@@ -106,12 +121,10 @@ UniquePtr<T>::~UniquePtr()
 #endif
 }
 
-/*
 template<class T> inline
 const Ptr<T> UniquePtr<T>::ptr() const {
   return ptr_.ptr();
 }
-*/
 
 template<class T> inline
 T* UniquePtr<T>::get() const

--- a/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
+++ b/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
@@ -64,9 +64,15 @@ public:
 #endif
           ), d_(d) { }
   ~UniquePtr();
+
   // Copy constructor and assignment are disabled
   inline UniquePtr(const UniquePtr<T>& ptr) = delete;
+  template<class U, class E>
+  inline UniquePtr(const UniquePtr<U, E>& ptr) = delete;
   UniquePtr<T>& operator=(const UniquePtr<T>& ptr) = delete;
+  template<class U, class E>
+  UniquePtr<T>& operator=(const UniquePtr<U, E>& ptr) = delete;
+
   // Move constructor and assignment
   inline UniquePtr(UniquePtr &&r_ptr) : ptr_(r_ptr.release()) { }
   template<class U, class E>

--- a/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
+++ b/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
@@ -80,6 +80,9 @@ public:
 
   /** \brief Return a Ptr<const T> version of *this. */
   inline Ptr<const T> getConst() const;
+
+  /** \brief Reset to null. */
+  inline void reset();
 private:
 #ifdef TEUCHOS_DEBUG
   RCP<T> ptr_;
@@ -142,6 +145,12 @@ template<class T> inline
 Ptr<const T> UniquePtr<T>::getConst() const
 {
   return uniqueptr_implicit_cast<const T>(*this);
+}
+
+template<class T> inline
+void UniquePtr<T>::reset()
+{
+  ptr_.reset();
 }
 
 //------------------------------------------------------

--- a/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
+++ b/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
@@ -255,8 +255,7 @@ inline T* UniquePtr<T, Deleter>::release()
 template<class T, class Deleter>
 inline void UniquePtr<T, Deleter>::swap(UniquePtr & other) noexcept
 {
-  std::swap(std::get<0>(t_), std::get<0>(other.t_));
-  std::swap(get_deleter(), other.get_deleter());
+  std::swap(t_, other.t_);
 }
 
 template<class T, class Deleter>

--- a/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
+++ b/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
@@ -302,7 +302,7 @@ UniquePtr<T, Deleter>::operator bool() const
 template<class T, class Deleter>
 inline bool UniquePtr<T, Deleter>::is_null() const
 {
-  return get() == nullptr;
+  return !bool(*this);
 }
 
 template<class T, class Deleter>
@@ -358,7 +358,7 @@ template<class T, class Deleter=std::default_delete<T>>
 inline
 bool is_null( const UniquePtr<T, Deleter> &p )
 {
-  return p.get() == 0;
+  return !bool(p);
 }
 
 /** \brief Returns true if <tt>p.get()!=NULL</tt>
@@ -369,7 +369,7 @@ template<class T, class Deleter=std::default_delete<T>>
 inline
 bool nonnull( const UniquePtr<T, Deleter> &p )
 {
-  return p.get() != 0;
+  return bool(p);
 }
 
 #endif // HAVE_TEUCHOSCORE_CXX11

--- a/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
+++ b/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
@@ -97,6 +97,15 @@ public:
   /** \brief Reset to null. */
   inline void reset();
 
+  inline T* release() {
+    T *p = get();
+#ifdef TEUCHOS_DEBUG
+    ptr_.release(); // So that the next line does not delete the object
+#endif
+    ptr_ = null;
+    return p;
+  }
+
   // FIXME: DO NOT USE THESE
 #ifdef TEUCHOS_DEBUG
   inline RCP<T> get_ptr_() {

--- a/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
+++ b/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
@@ -66,13 +66,13 @@ public:
   // Move constructor and assignment
   inline UniquePtr(UniquePtr&&) = default;
   UniquePtr<T>& operator=(UniquePtr&&) = default;
-  inline T* operator->() const { return ptr_; }
-  inline T& operator*() const { return *ptr_; }
+//  inline T* operator->() const { return ptr_; }
+//  inline T& operator*() const { return *ptr_; }
 
   /** \brief Get the raw C++ pointer to the underlying object. */
   inline T* get() const;
 
-  inline const Ptr<T> ptr() const;
+//  inline const Ptr<T> ptr() const;
 private:
 #ifdef TEUCHOS_DEBUG
   RCP<T> ptr_;
@@ -94,10 +94,12 @@ UniquePtr<T>::~UniquePtr()
 #endif
 }
 
+/*
 template<class T> inline
 const Ptr<T> UniquePtr<T>::ptr() const {
   return ptr_.ptr();
 }
+*/
 
 template<class T> inline
 T* UniquePtr<T>::get() const

--- a/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
+++ b/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
@@ -136,7 +136,9 @@ public:
     return d_;
   }
 
-  // FIXME: operator bool
+  explicit operator bool() const {
+    return get() != nullptr;
+  }
 
   /*
    *                   Dereferencing

--- a/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
+++ b/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
@@ -57,24 +57,14 @@ class UniquePtr {
 public:
   inline UniquePtr( ENull null_in = null );
 
-  inline explicit UniquePtr( T *ptr_in ) : ptr_(ptr_in) { }
+  inline explicit UniquePtr( T *ptr_in );
 
   inline UniquePtr( T *ptr_in,
       typename std::conditional<std::is_reference<Deleter>::value,
-        Deleter, const Deleter&>::type d)
-      : ptr_(ptr_in
-#ifdef TEUCHOS_DEBUG
-          , deallocFunctorDelete<T, Deleter>(d), true
-#endif
-          ), d_(d) { }
+        Deleter, const Deleter&>::type d);
 
   inline UniquePtr( T *ptr_in,
-      typename std::remove_reference<Deleter>::type &&d)
-      : ptr_(ptr_in
-#ifdef TEUCHOS_DEBUG
-          , deallocFunctorDelete<T, Deleter>(d), true
-#endif
-          ), d_(std::move(d)) { }
+      typename std::remove_reference<Deleter>::type &&d);
 
   ~UniquePtr();
 
@@ -87,12 +77,10 @@ public:
   UniquePtr<T>& operator=(const UniquePtr<U, E>& ptr) = delete;
 
   // Move constructor and assignment
-  inline UniquePtr(UniquePtr &&r_ptr) : ptr_(r_ptr.release()),
-      d_(std::forward<Deleter>(r_ptr.get_deleter())) { }
+  inline UniquePtr(UniquePtr &&r_ptr);
 
   template<class U, class E>
-  inline UniquePtr(UniquePtr<U, E> &&r_ptr) : ptr_(r_ptr.release()),
-      d_(std::forward<E>(r_ptr.get_deleter())) { }
+  inline UniquePtr(UniquePtr<U, E> &&r_ptr);
 
   inline UniquePtr& operator=(UniquePtr &&r_ptr);
 
@@ -104,22 +92,12 @@ public:
    *                   Modifiers
    */
 
-  inline T* release() {
-    T *p = get();
-#ifdef TEUCHOS_DEBUG
-    ptr_.release(); // So that the next line does not delete the object
-#endif
-    ptr_ = null;
-    return p;
-  }
+  inline T* release();
 
   /** \brief Reset to r_ptr (default: null). */
   inline void reset(T *r_ptr=nullptr);
 
-  void swap(UniquePtr & other) noexcept {
-    std::swap(ptr_, other.ptr_);
-    std::swap(get_deleter(), other.get_deleter());
-  }
+  inline void swap(UniquePtr & other) noexcept;
 
   /*
    *                   Observers
@@ -128,24 +106,18 @@ public:
   /** \brief Get the raw C++ pointer to the underlying object. */
   inline T* get() const;
 
-  Deleter& get_deleter() noexcept {
-    return d_;
-  }
+  inline Deleter& get_deleter() noexcept;
 
-  const Deleter& get_deleter() const noexcept {
-    return d_;
-  }
+  inline const Deleter& get_deleter() const noexcept;
 
-  explicit operator bool() const {
-    return get() != nullptr;
-  }
+  inline explicit operator bool() const;
 
   /*
    *                   Dereferencing
    */
 
-  inline T* operator->() const { return ptr_.operator->(); }
-  inline T& operator*() const { return ptr_.operator*(); }
+  inline T* operator->() const;
+  inline T& operator*() const;
 
   /*
    *                   Observers Ptr
@@ -195,8 +167,33 @@ Ptr<T2> uniqueptr_implicit_cast(const UniquePtr<T1, Deleter>& p1)
 // Implementation of UniquePtr
 
 template<class T, class Deleter>
-UniquePtr<T, Deleter>::UniquePtr( ENull /*null_in*/ )
+inline UniquePtr<T, Deleter>::UniquePtr( ENull /*null_in*/ )
   : ptr_(0)
+{}
+
+template<class T, class Deleter>
+inline UniquePtr<T, Deleter>::UniquePtr( T *ptr_in ) : ptr_(ptr_in)
+{}
+
+template<class T, class Deleter>
+inline UniquePtr<T, Deleter>::UniquePtr( T *ptr_in,
+      typename std::conditional<std::is_reference<Deleter>::value,
+        Deleter, const Deleter&>::type d)
+  : ptr_(ptr_in
+#ifdef TEUCHOS_DEBUG
+        , deallocFunctorDelete<T, Deleter>(d), true
+#endif
+        ), d_(d)
+{}
+
+template<class T, class Deleter>
+inline UniquePtr<T, Deleter>::UniquePtr( T *ptr_in,
+    typename std::remove_reference<Deleter>::type &&d)
+  : ptr_(ptr_in
+#ifdef TEUCHOS_DEBUG
+        , deallocFunctorDelete<T, Deleter>(d), true
+#endif
+        ), d_(std::move(d))
 {}
 
 template<class T, class Deleter>
@@ -206,6 +203,17 @@ UniquePtr<T, Deleter>::~UniquePtr()
   d_(ptr_.get()); // Note: the pointer can be null
 #endif
 }
+
+template<class T, class Deleter>
+inline UniquePtr<T, Deleter>::UniquePtr(UniquePtr &&r_ptr)
+  : ptr_(r_ptr.release()), d_(std::forward<Deleter>(r_ptr.get_deleter()))
+{}
+
+template<class T, class Deleter>
+template<class U, class E>
+inline UniquePtr<T, Deleter>::UniquePtr(UniquePtr<U, E> &&r_ptr)
+  : ptr_(r_ptr.release()), d_(std::forward<E>(r_ptr.get_deleter()))
+{}
 
 template<class T, class Deleter>
 inline
@@ -230,10 +238,49 @@ inline UniquePtr<T, Deleter>& UniquePtr<T, Deleter>::operator=(UniquePtr<U, E> &
 }
 
 template<class T, class Deleter>
+inline T* UniquePtr<T, Deleter>::release()
+{
+  T *p = get();
+#ifdef TEUCHOS_DEBUG
+  ptr_.release(); // So that the next line does not delete the object
+#endif
+  ptr_ = null;
+  return p;
+}
+
+template<class T, class Deleter>
+inline void UniquePtr<T, Deleter>::swap(UniquePtr & other) noexcept
+{
+  std::swap(ptr_, other.ptr_);
+  std::swap(get_deleter(), other.get_deleter());
+}
+
+template<class T, class Deleter>
 inline
 T* UniquePtr<T, Deleter>::get() const
 {
   return ptr_.get();
+}
+
+template<class T, class Deleter>
+inline
+Deleter& UniquePtr<T, Deleter>::get_deleter() noexcept
+{
+  return d_;
+}
+
+template<class T, class Deleter>
+inline
+const Deleter& UniquePtr<T, Deleter>::get_deleter() const noexcept
+{
+  return d_;
+}
+
+template<class T, class Deleter>
+inline
+UniquePtr<T, Deleter>::operator bool() const
+{
+  return get() != nullptr;
 }
 
 template<class T, class Deleter>
@@ -248,6 +295,19 @@ inline
 Ptr<const T> UniquePtr<T, Deleter>::getConst() const
 {
   return uniqueptr_implicit_cast<const T>(*this);
+}
+
+template<class T, class Deleter>
+inline
+T* UniquePtr<T, Deleter>::operator->() const
+{
+  return ptr_.operator->();
+}
+
+template<class T, class Deleter>
+inline
+T& UniquePtr<T, Deleter>::operator*() const {
+  return ptr_.operator*();
 }
 
 template<class T, class Deleter>

--- a/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
+++ b/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
@@ -72,6 +72,9 @@ public:
   /** \brief Get the raw C++ pointer to the underlying object. */
   inline T* get() const;
 
+  /** \brief Get the raw C++ pointer to the underlying object. */
+  inline T* getRawPtr() const;
+
 //  inline const Ptr<T> ptr() const;
 private:
 #ifdef TEUCHOS_DEBUG
@@ -105,6 +108,12 @@ template<class T> inline
 T* UniquePtr<T>::get() const
 {
   return ptr_.get();
+}
+
+template<class T> inline
+T* UniquePtr<T>::getRawPtr() const
+{
+  return get();
 }
 
 /** \brief Returns true if <tt>p.get()==NULL</tt>.

--- a/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
+++ b/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
@@ -59,9 +59,7 @@ public:
   inline explicit UniquePtr( T *ptr_in ) : ptr_(ptr_in) {
 //        ASSERT(ptr != nullptr)
   }
-#ifndef TEUCHOS_DEBUG
-  ~UniquePtr() { delete ptr_.get(); }
-#endif
+  ~UniquePtr();
   // Copy constructor and assignment are disabled
   inline UniquePtr(const UniquePtr<T>& ptr) = delete;
   UniquePtr<T>& operator=(const UniquePtr<T>& ptr) = delete;
@@ -87,6 +85,14 @@ template<class T> inline
 UniquePtr<T>::UniquePtr( ENull /*null_in*/ )
   : ptr_(0)
 {}
+
+template<class T>
+UniquePtr<T>::~UniquePtr()
+{
+#ifndef TEUCHOS_DEBUG
+  delete ptr_.get();
+#endif
+}
 
 template<class T> inline
 const Ptr<T> UniquePtr<T>::ptr() const {

--- a/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
+++ b/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
@@ -87,7 +87,8 @@ public:
   UniquePtr<T>& operator=(const UniquePtr<U, E>& ptr) = delete;
 
   // Move constructor and assignment
-  inline UniquePtr(UniquePtr &&r_ptr) : ptr_(r_ptr.release()) { }
+  inline UniquePtr(UniquePtr &&r_ptr) : ptr_(r_ptr.release()),
+      d_(std::forward<Deleter>(r_ptr.d_)) { }
   template<class U, class E>
   inline UniquePtr(UniquePtr<U, E> &&r_ptr) : ptr_(r_ptr.release()) { }
   UniquePtr<T>& operator=(UniquePtr &&r_ptr) {

--- a/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
+++ b/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
@@ -55,31 +55,31 @@ namespace Teuchos {
 template<class T>
 class UniquePtr {
 public:
-    inline UniquePtr( ENull null_in = null );
-    inline explicit UniquePtr( T *ptr_in ) : ptr_(ptr_in) {
+  inline UniquePtr( ENull null_in = null );
+  inline explicit UniquePtr( T *ptr_in ) : ptr_(ptr_in) {
 //        ASSERT(ptr != nullptr)
-    }
+  }
 #ifndef TEUCHOS_DEBUG
-    ~UniquePtr() { delete ptr_.get(); }
+  ~UniquePtr() { delete ptr_.get(); }
 #endif
-    // Copy constructor and assignment are disabled
-    inline UniquePtr(const UniquePtr<T>& ptr) = delete;
-    UniquePtr<T>& operator=(const UniquePtr<T>& ptr) = delete;
-    // Move constructor and assignment
-    inline UniquePtr(UniquePtr&&) = default;
-    UniquePtr<T>& operator=(UniquePtr&&) = default;
-    inline T* operator->() const { return ptr_; }
-    inline T& operator*() const { return *ptr_; }
+  // Copy constructor and assignment are disabled
+  inline UniquePtr(const UniquePtr<T>& ptr) = delete;
+  UniquePtr<T>& operator=(const UniquePtr<T>& ptr) = delete;
+  // Move constructor and assignment
+  inline UniquePtr(UniquePtr&&) = default;
+  UniquePtr<T>& operator=(UniquePtr&&) = default;
+  inline T* operator->() const { return ptr_; }
+  inline T& operator*() const { return *ptr_; }
 
-    /** \brief Get the raw C++ pointer to the underlying object. */
-    inline T* get() const;
+  /** \brief Get the raw C++ pointer to the underlying object. */
+  inline T* get() const;
 
-    inline const Ptr<T> ptr() const;
+  inline const Ptr<T> ptr() const;
 private:
 #ifdef TEUCHOS_DEBUG
-    RCP<T> ptr_;
+  RCP<T> ptr_;
 #else
-    Ptr<T> ptr_;
+  Ptr<T> ptr_;
 #endif
 };
 
@@ -90,13 +90,13 @@ UniquePtr<T>::UniquePtr( ENull /*null_in*/ )
 
 template<class T> inline
 const Ptr<T> UniquePtr<T>::ptr() const {
-    return ptr_.ptr();
+  return ptr_.ptr();
 }
 
 template<class T> inline
 T* UniquePtr<T>::get() const
 {
-    return ptr_.get();
+  return ptr_.get();
 }
 
 /** \brief Returns true if <tt>p.get()==NULL</tt>.
@@ -106,7 +106,7 @@ T* UniquePtr<T>::get() const
 template<class T> inline
 bool is_null( const UniquePtr<T> &p )
 {
-    return p.get() == 0;
+  return p.get() == 0;
 }
 
 /** \brief Returns true if <tt>p.get()!=NULL</tt>

--- a/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
+++ b/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
@@ -66,8 +66,8 @@ public:
   // Move constructor and assignment
   inline UniquePtr(UniquePtr&&) = default;
   UniquePtr<T>& operator=(UniquePtr&&) = default;
-//  inline T* operator->() const { return ptr_; }
-//  inline T& operator*() const { return *ptr_; }
+  inline T* operator->() const { return ptr_.get(); }
+  inline T& operator*() const { return *ptr_; }
 
   /** \brief Get the raw C++ pointer to the underlying object. */
   inline T* get() const;

--- a/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
+++ b/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
@@ -56,13 +56,26 @@ template<class T, class Deleter=std::default_delete<T>>
 class UniquePtr {
 public:
   inline UniquePtr( ENull null_in = null );
+
   inline explicit UniquePtr( T *ptr_in ) : ptr_(ptr_in) { }
-  inline explicit UniquePtr( T *ptr_in, const Deleter &d)
+
+  inline UniquePtr( T *ptr_in,
+      typename std::conditional<std::is_reference<Deleter>::value,
+        Deleter, const Deleter&>::type d)
       : ptr_(ptr_in
 #ifdef TEUCHOS_DEBUG
           , deallocFunctorDelete<T, Deleter>(d), true
 #endif
           ), d_(d) { }
+
+  inline UniquePtr( T *ptr_in,
+      typename std::remove_reference<Deleter>::type &&d)
+      : ptr_(ptr_in
+#ifdef TEUCHOS_DEBUG
+          , deallocFunctorDelete<T, Deleter>(d), true
+#endif
+          ), d_(std::move(d)) { }
+
   ~UniquePtr();
 
   // Copy constructor and assignment are disabled

--- a/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
+++ b/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
@@ -55,7 +55,8 @@ namespace Teuchos {
 template<class T>
 class UniquePtr {
 public:
-    inline explicit UniquePtr( T *ptr ) : ptr_(ptr) {
+    inline UniquePtr( ENull null_in = null );
+    inline explicit UniquePtr( T *ptr_in ) : ptr_(ptr_in) {
 //        ASSERT(ptr != nullptr)
     }
 #ifndef TEUCHOS_DEBUG
@@ -65,17 +66,15 @@ public:
     inline UniquePtr(const UniquePtr<T>& ptr) = delete;
     UniquePtr<T>& operator=(const UniquePtr<T>& ptr) = delete;
     // Move constructor and assignment
-    inline UniquePtr(UniquePtr&&) = delete;
-    UniquePtr<T>& operator=(UniquePtr&&) = delete;
+    inline UniquePtr(UniquePtr&&) = default;
+    UniquePtr<T>& operator=(UniquePtr&&) = default;
     inline T* operator->() const { return ptr_; }
     inline T& operator*() const { return *ptr_; }
-    inline const Ptr<T> ptr() const {
-#ifdef TEUCHOS_DEBUG
-        return ptr_.ptr();
-#else
-        return Ptr<T>(ptr_);
-#endif
-    }
+
+    /** \brief Get the raw C++ pointer to the underlying object. */
+    inline T* get() const;
+
+    inline const Ptr<T> ptr() const;
 private:
 #ifdef TEUCHOS_DEBUG
     RCP<T> ptr_;
@@ -84,8 +83,41 @@ private:
 #endif
 };
 
+template<class T> inline
+UniquePtr<T>::UniquePtr( ENull /*null_in*/ )
+  : ptr_(0)
+{}
 
+template<class T> inline
+const Ptr<T> UniquePtr<T>::ptr() const {
+#ifdef TEUCHOS_DEBUG
+    return ptr_.ptr();
+#else
+    return Ptr<T>(ptr_);
 #endif
+}
+
+template<class T> inline
+T* UniquePtr<T>::get() const
+{
+#ifdef TEUCHOS_DEBUG
+    return ptr_.get();
+#else
+    return ptr_;
+#endif
+}
+
+/** \brief Returns true if <tt>p.get()==NULL</tt>.
+ *
+ * \relates UniquePtr
+ */
+template<class T> inline
+bool is_null( const UniquePtr<T> &p )
+{
+    return p.get() == 0;
+}
+
+#endif // HAVE_TEUCHOSCORE_CXX11
 
 
 } // namespace Teuchos

--- a/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
+++ b/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
@@ -64,8 +64,13 @@ public:
   inline UniquePtr(const UniquePtr<T>& ptr) = delete;
   UniquePtr<T>& operator=(const UniquePtr<T>& ptr) = delete;
   // Move constructor and assignment
-  inline UniquePtr(UniquePtr&&) = default;
-  UniquePtr<T>& operator=(UniquePtr&&) = default;
+  inline UniquePtr(UniquePtr &&r_ptr) : ptr_(r_ptr.ptr_) {
+    r_ptr.ptr_ = null;
+  }
+  UniquePtr<T>& operator=(UniquePtr &&r_ptr) {
+    std::swap(ptr_, r_ptr.ptr_);
+    return *this;
+  }
   inline T* operator->() const { return ptr_.get(); }
   inline T& operator*() const { return *ptr_; }
 

--- a/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
+++ b/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
@@ -71,6 +71,10 @@ public:
   inline UniquePtr(UniquePtr &&r_ptr) : ptr_(r_ptr.ptr_) {
     r_ptr.ptr_ = null;
   }
+  template<class U, class E>
+  inline UniquePtr(UniquePtr<U, E> &&r_ptr) : ptr_(r_ptr.get_ptr_()) {
+    r_ptr.set_ptr_null_();
+  }
   UniquePtr<T>& operator=(UniquePtr &&r_ptr) {
     std::swap(ptr_, r_ptr.ptr_);
     return *this;
@@ -92,6 +96,19 @@ public:
 
   /** \brief Reset to null. */
   inline void reset();
+
+  // FIXME: DO NOT USE THESE
+#ifdef TEUCHOS_DEBUG
+  inline RCP<T> get_ptr_() {
+#else
+  inline Ptr<T> get_ptr_() {
+#endif
+    return ptr_;
+  }
+
+  inline void set_ptr_null_() {
+    ptr_ = null;
+  }
 private:
 #ifdef TEUCHOS_DEBUG
   RCP<T> ptr_;

--- a/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
+++ b/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
@@ -99,6 +99,14 @@ public:
     get_deleter() = std::forward<Deleter>(r_ptr.get_deleter());
     return *this;
   }
+
+  template<class U, class E>
+  UniquePtr& operator=(UniquePtr<U, E> &&r_ptr) {
+    reset(r_ptr.release());
+    get_deleter() = std::forward<E>(r_ptr.get_deleter());
+    return *this;
+  }
+
   inline T* operator->() const { return ptr_.operator->(); }
   inline T& operator*() const { return ptr_.operator*(); }
 

--- a/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
+++ b/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
@@ -375,4 +375,4 @@ void UniquePtr<T, Deleter>::reset(T *r_ptr)
 
 } // namespace Teuchos
 
-#endif // TEUCHOS_PTR_HPP
+#endif // TEUCHOS_UNIQUEPTR_HPP

--- a/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
+++ b/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
@@ -150,7 +150,12 @@ Ptr<const T> UniquePtr<T>::getConst() const
 template<class T> inline
 void UniquePtr<T>::reset()
 {
+#ifdef TEUCHOS_DEBUG
   ptr_.reset();
+#else
+  delete ptr_.get();
+  ptr_ = null;
+#endif
 }
 
 //------------------------------------------------------

--- a/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
+++ b/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
@@ -217,7 +217,7 @@ void UniquePtr<T, Deleter>::reset(T *r_ptr)
 {
 #ifdef TEUCHOS_DEBUG
   ptr_.reset();
-  ptr_ = rcp(r_ptr);
+  ptr_ = rcpWithDealloc(r_ptr, deallocFunctorDelete<T, Deleter>(d_));
 #else
   d_(ptr_.get()); // Note: the pointer can be null
   ptr_ = Ptr<T>(r_ptr);

--- a/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
+++ b/packages/teuchos/core/src/Teuchos_UniquePtr.hpp
@@ -122,9 +122,6 @@ public:
   /** \brief Return a Ptr<const T> version of *this. */
   inline Ptr<const T> getConst() const;
 
-  /** \brief Reset to null. */
-  inline void reset(T *r_ptr=nullptr);
-
   inline T* release() {
     T *p = get();
 #ifdef TEUCHOS_DEBUG
@@ -132,6 +129,14 @@ public:
 #endif
     ptr_ = null;
     return p;
+  }
+
+  /** \brief Reset to r_ptr (default: null). */
+  inline void reset(T *r_ptr=nullptr);
+
+  void swap(UniquePtr & other) noexcept {
+    std::swap(ptr_, other.ptr_);
+    std::swap(get_deleter(), other.get_deleter());
   }
 
   Deleter& get_deleter() noexcept {

--- a/packages/teuchos/core/src/Teuchos_toString.hpp
+++ b/packages/teuchos/core/src/Teuchos_toString.hpp
@@ -47,6 +47,11 @@
 
 namespace Teuchos {
 
+inline
+std::ostream& operator<<(std::ostream& out, const std::nullptr_t)
+{
+  return (out << "nullptr");
+}
 
 /** \brief Default traits class for converting objects into strings.
  *

--- a/packages/teuchos/core/src/Teuchos_toString.hpp
+++ b/packages/teuchos/core/src/Teuchos_toString.hpp
@@ -47,11 +47,13 @@
 
 namespace Teuchos {
 
+#ifdef HAVE_TEUCHOSCORE_CXX11
 inline
 std::ostream& operator<<(std::ostream& out, const std::nullptr_t)
 {
   return (out << "nullptr");
 }
+#endif
 
 /** \brief Default traits class for converting objects into strings.
  *

--- a/packages/teuchos/core/test/MemoryManagement/CMakeLists.txt
+++ b/packages/teuchos/core/test/MemoryManagement/CMakeLists.txt
@@ -114,6 +114,7 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   SOURCES
     RCP_UnitTests.cpp
     RCP_ForwardDeclUnitTests.cpp
+    UniquePtr_UnitTests.cpp
     Ptr_UnitTests.cpp
     Array_UnitTest_helpers.cpp
     Array_UnitTests.cpp

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -139,6 +139,26 @@ TEUCHOS_UNIT_TEST( UniquePtr, danglingPtr2 )
 #endif
 }
 
+TEUCHOS_UNIT_TEST( UniquePtr, danglingPtr3 )
+{
+  ECHO(Ptr<A> a_ptr);
+  ECHO(A *badPtr = 0);
+  {
+    ECHO(UniquePtr<A> a_uptr = uniqueptr(new A));
+    ECHO(badPtr = a_uptr.getRawPtr());
+    ECHO(Ptr<A> a_ptr2(a_uptr.ptr()));
+    ECHO(Ptr<A> a_ptr3(a_ptr2));
+    ECHO(a_ptr = a_ptr3);
+    TEST_EQUALITY( a_ptr.getRawPtr(), badPtr );
+  }
+#ifdef TEUCHOS_DEBUG
+  TEST_THROW( *a_ptr, DanglingReferenceError );
+  (void)badPtr;
+#else
+  TEST_EQUALITY( a_ptr.getRawPtr(), badPtr );
+#endif
+}
+
 #endif // HAVE_TEUCHOSCORE_CXX11
 
 

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -402,6 +402,15 @@ bool test_unique_ptr_interface()
     if (flags != 6) return false;
   }
 
+  // Test 12
+  {
+    UPtr<Foo, D&> up(new Foo(), d);
+    UPtr<Foo, D> up2;
+    flags = 0;
+    up2 = std::move(up);
+    if (flags != 5) return false;
+  }
+
   // Success
   return true;
 }

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -159,6 +159,25 @@ TEUCHOS_UNIT_TEST( UniquePtr, danglingPtr3 )
 #endif
 }
 
+TEUCHOS_UNIT_TEST( UniquePtr, danglingPtr4 )
+{
+  ECHO(Ptr<A> a_ptr);
+  ECHO(A *badPtr = 0);
+  {
+    ECHO(UniquePtr<C> c_uptr = uniqueptr(new C));
+    ECHO(badPtr = c_uptr.getRawPtr());
+    ECHO(Ptr<A> a_ptr2(c_uptr.ptr()));
+    ECHO(a_ptr = a_ptr2);
+    TEST_EQUALITY( a_ptr.getRawPtr(), badPtr );
+  }
+#ifdef TEUCHOS_DEBUG
+  TEST_THROW( *a_ptr, DanglingReferenceError );
+  (void)badPtr;
+#else
+  TEST_EQUALITY( a_ptr.getRawPtr(), badPtr );
+#endif
+}
+
 #endif // HAVE_TEUCHOSCORE_CXX11
 
 

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -294,7 +294,10 @@ struct D { // deleter
   };
 };
 
+// FIXME: Temporary macros --- we should figure out how to use TEST_ASSERT and
+// TEST_EQUALITY instead in the function below.
 #define TEST_ASSERT2(x) if (!(x)) return false
+#define TEST_EQUALITY2(a, b) TEST_ASSERT2((a) == (b))
 
 template <template <typename T, typename Deleter=std::default_delete<T>> class UPtr>
 bool test_unique_ptr_interface()
@@ -323,9 +326,9 @@ bool test_unique_ptr_interface()
 
   // Test 4
   UPtr<Foo> up1;
-  TEST_ASSERT2(up1.get() == nullptr);
+  TEST_EQUALITY2(up1.get(), nullptr);
   UPtr<Foo> up1b(nullptr);
-  TEST_ASSERT2(up1b.get() == nullptr);
+  TEST_EQUALITY2(up1b.get(), nullptr);
 
   // Test 5
   {
@@ -410,14 +413,14 @@ bool test_unique_ptr_interface()
     UPtr<Foo, D> up2;
     flags = 0;
     up2 = std::move(up);
-    TEST_ASSERT2(flags == 5);
+    TEST_EQUALITY2(flags, 5);
   }
 
   // Test 13
   {
     UPtr<Foo> up(new Foo());
     up.reset();
-    TEST_ASSERT2(up.get() == nullptr);
+    TEST_EQUALITY2(up.get(), nullptr);
   }
 
   // Success

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -84,6 +84,15 @@ TEUCHOS_UNIT_TEST( UniquePtr, assignSelf_null )
   TEST_ASSERT(is_null(a_rcp));
 }
 
+TEUCHOS_UNIT_TEST( UniquePtr, assignSelf_nonnull )
+{
+  UniquePtr<A> a_rcp(new A);
+  A *a_raw_ptr = a_rcp.get();
+  a_rcp = std::move(a_rcp);
+  TEST_ASSERT(nonnull(a_rcp));
+  TEST_EQUALITY(a_rcp.get(), a_raw_ptr);
+}
+
 #endif // HAVE_TEUCHOSCORE_CXX11
 
 

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -275,11 +275,19 @@ TEUCHOS_UNIT_TEST( UniquePtr, danglingPtr4 )
 template <template <typename T, typename Deleter=std::default_delete<T>> class UPtr>
 bool test_unique_ptr_interface()
 {
+  // Test 1
   UPtr<A> p1(new A);
   {
     UPtr<A> p2(std::move(p1));
     p1 = std::move(p2);
   }
+
+  // Test 2
+  int x = 5;
+  auto del = [](int * p) { std::cout << "Deleting x, value is : " << *p; };
+  UPtr<int, decltype(del)> px(&x, del);
+
+  // Success
   return true;
 }
 

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -535,23 +535,6 @@ TEUCHOS_UNIT_TEST( UniquePtr, std_unique_ptr_interface )
 {
   test_unique_ptr_interface<std::unique_ptr>(out, success);
   test_unique_ptr_interface<UniquePtr>(out, success);
-  A *a;
-  std::tuple<A*, std::default_delete<A>> t;
-  std::tuple<Ptr<A>, std::default_delete<A>, int> t2;
-  int x = 5;
-  auto del = [](int * p) { std::cout << "Deleting x, value is : " << *p; };
-  std::unique_ptr<int, decltype(del)> px(&x, del);
-  std::cout << "SIZE: " << sizeof(std::default_delete<A>) << std::endl;
-  std::cout << "SIZE: " << sizeof(std::unique_ptr<A>) << std::endl;
-  std::cout << "SIZE: " << sizeof(UniquePtr<A>) << std::endl;
-  std::cout << "SIZE: " << sizeof(Ptr<A>) << std::endl;
-  std::cout << "SIZE: " << sizeof(a) << std::endl;
-  std::cout << "SIZE: " << sizeof(t) << std::endl;
-  std::cout << "SIZE: " << sizeof(t2) << std::endl;
-  std::cout << "SIZE: " << sizeof(px) << std::endl;
-  std::cout << "XX: " << &std::get<0>(t2) << std::endl;
-  std::cout << "XX: " << &std::get<1>(t2) << std::endl;
-  std::cout << "XX: " << &std::get<2>(t2) << std::endl;
 }
 
 #endif // HAVE_TEUCHOSCORE_CXX11

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -307,14 +307,8 @@ struct D2 { // deleter
   int val;
 };
 
-// FIXME: Temporary macros --- we should figure out how to use TEST_ASSERT,
-// TEST_EQUALITY and TEST_INEQUALITY instead in the function below.
-#define TEST_ASSERT2(x) if (!(x)) return false
-#define TEST_EQUALITY2(a, b) TEST_ASSERT2((a) == (b))
-#define TEST_INEQUALITY2(a, b) TEST_ASSERT2((a) != (b))
-
 template <template <typename T, typename Deleter=std::default_delete<T>> class UPtr>
-bool test_unique_ptr_interface()
+void test_unique_ptr_interface(Teuchos::FancyOStream &out, bool &success)
 {
   // Test 1
   {
@@ -338,85 +332,85 @@ bool test_unique_ptr_interface()
     int x2 = 5;
     auto del2 = [&deleted](int * p) { deleted = true; };
     {
-      TEST_ASSERT2(!deleted);
+      TEST_ASSERT(!deleted);
       UPtr<int, decltype(del2)> px2(&x2, del2);
     }
-    TEST_ASSERT2(deleted);
+    TEST_ASSERT(deleted);
   }
 
   // Test 4
   {
     UPtr<Foo> up1;
-    TEST_EQUALITY2(up1.get(), nullptr);
+    TEST_EQUALITY(up1.get(), nullptr);
     UPtr<Foo> up1b(nullptr);
-    TEST_EQUALITY2(up1b.get(), nullptr);
+    TEST_EQUALITY(up1b.get(), nullptr);
   }
 
   // Test 5
   {
     UPtr<Foo> up2(new Foo);
-    TEST_INEQUALITY2(up2.get(), nullptr);
+    TEST_INEQUALITY(up2.get(), nullptr);
   }
 
   // Test 6
   flags = 0;
   D d;
-  TEST_EQUALITY2(flags, 1);
+  TEST_EQUALITY(flags, 1);
   {
     flags = 0;
     UPtr<Foo, D> up3(new Foo, d); // deleter copied
-    TEST_EQUALITY2(flags, 2);
-    TEST_INEQUALITY2(up3.get(),  nullptr);
+    TEST_EQUALITY(flags, 2);
+    TEST_INEQUALITY(up3.get(),  nullptr);
   }
   {
     flags = 0;
     UPtr<Foo, D&> up3b(new Foo, d); // up3b holds a reference to d
-    TEST_EQUALITY2(flags, 0);
-    TEST_INEQUALITY2(up3b.get(), nullptr);
+    TEST_EQUALITY(flags, 0);
+    TEST_INEQUALITY(up3b.get(), nullptr);
   }
 
   // Test 7
   {
     flags = 0;
     UPtr<Foo, D> up4(new Foo, D()); // deleter moved
-    TEST_EQUALITY2(flags, 4);
-    TEST_INEQUALITY2(up4.get(), nullptr);
+    TEST_EQUALITY(flags, 4);
+    TEST_INEQUALITY(up4.get(), nullptr);
   }
 
   // Test 8
   {
     UPtr<Foo> up5a(new Foo);
-    TEST_INEQUALITY2(up5a.get(), nullptr);
+    TEST_INEQUALITY(up5a.get(), nullptr);
     UPtr<Foo> up5b(std::move(up5a)); // ownership transfer
-    TEST_EQUALITY2(up5a.get(), nullptr);
-    TEST_INEQUALITY2(up5b.get(), nullptr);
+    TEST_EQUALITY(up5a.get(), nullptr);
+    TEST_INEQUALITY(up5b.get(), nullptr);
   }
 
   // Test 9
   {
     flags = 0;
     UPtr<Foo, D> up6a(new Foo, d); // D is copied
-    TEST_EQUALITY2(flags, 2);
+    TEST_EQUALITY(flags, 2);
     flags = 0;
     UPtr<Foo, D> up6b(std::move(up6a)); // D is moved
-    TEST_EQUALITY2(flags, 4);
+    TEST_EQUALITY(flags, 4);
 
     flags = 0;
     UPtr<Foo, D&> up6c(new Foo, d); // D is a reference
-    TEST_EQUALITY2(flags, 0);
+    TEST_EQUALITY(flags, 0);
     flags = 0;
     UPtr<Foo, D> up6d(std::move(up6c)); // D is copied
-    TEST_EQUALITY2(flags, 3);
+    TEST_EQUALITY(flags, 3);
   }
 
   // Test 10
   {
     UPtr<Foo> up(new Foo());
-    TEST_ASSERT2(up);
+    TEST_ASSERT(up);
     Foo *fp = up.release();
-    TEST_EQUALITY2(up.get(), nullptr);
-    TEST_ASSERT2(!(up));
-    TEST_INEQUALITY2(fp, nullptr);
+    TEST_EQUALITY(up.get(), nullptr);
+    TEST_ASSERT(!(up));
+    TEST_INEQUALITY(fp, nullptr);
     delete fp;
   }
 
@@ -426,7 +420,7 @@ bool test_unique_ptr_interface()
     UPtr<Foo, D> up2;
     flags = 0;
     up2 = std::move(up);
-    TEST_EQUALITY2(flags, 6);
+    TEST_EQUALITY(flags, 6);
   }
 
   // Test 12
@@ -435,79 +429,76 @@ bool test_unique_ptr_interface()
     UPtr<Foo, D> up2;
     flags = 0;
     up2 = std::move(up);
-    TEST_EQUALITY2(flags, 5);
+    TEST_EQUALITY(flags, 5);
   }
 
   // Test 13
   {
     UPtr<Foo> up(new Foo());
-    TEST_INEQUALITY2(up.get(), nullptr);
+    TEST_INEQUALITY(up.get(), nullptr);
     up.reset();
-    TEST_EQUALITY2(up.get(), nullptr);
+    TEST_EQUALITY(up.get(), nullptr);
   }
 
   // Test 14
   {
     UPtr<Foo> up(new Foo());
-    TEST_INEQUALITY2(up.get(), nullptr);
+    TEST_INEQUALITY(up.get(), nullptr);
     up.reset(new Foo());
-    TEST_INEQUALITY2(up.get(), nullptr);
+    TEST_INEQUALITY(up.get(), nullptr);
     up.reset(nullptr);
-    TEST_EQUALITY2(up.get(), nullptr);
+    TEST_EQUALITY(up.get(), nullptr);
   }
 
   // Test 15
   {
     flags = 0;
     UPtr<Foo, D> up(new Foo(), D());
-    TEST_EQUALITY2(flags, 4);
-    TEST_INEQUALITY2(up.get(), nullptr);
+    TEST_EQUALITY(flags, 4);
+    TEST_INEQUALITY(up.get(), nullptr);
     flags = 0;
     flags2 = 0;
     up.reset(new Foo());
-//    TEST_EQUALITY2(flags, 0); // Works in Release, fails in Debug mode
-    TEST_EQUALITY2(flags2, 7);
-    TEST_INEQUALITY2(up.get(), nullptr);
+//    TEST_EQUALITY(flags, 0); // Works in Release, fails in Debug mode
+    TEST_EQUALITY(flags2, 7);
+    TEST_INEQUALITY(up.get(), nullptr);
     flags2 = 0;
     up.reset(nullptr);
-    TEST_EQUALITY2(up.get(), nullptr);
-    TEST_EQUALITY2(flags2, 7);
+    TEST_EQUALITY(up.get(), nullptr);
+    TEST_EQUALITY(flags2, 7);
   }
 
   // Test 16
   {
     UPtr<Foo2> up1(new Foo2(1));
     UPtr<Foo2> up2(new Foo2(2));
-    TEST_EQUALITY2(up1->val, 1);
-    TEST_EQUALITY2(up2->val, 2);
+    TEST_EQUALITY(up1->val, 1);
+    TEST_EQUALITY(up2->val, 2);
     up1.swap(up2);
-    TEST_EQUALITY2(up1->val, 2);
-    TEST_EQUALITY2(up2->val, 1);
+    TEST_EQUALITY(up1->val, 2);
+    TEST_EQUALITY(up2->val, 1);
   }
 
   // Test 17
   {
     UPtr<Foo2, D2> up1(new Foo2(1), D2(1));
     UPtr<Foo2, D2> up2(new Foo2(2), D2(2));
-    TEST_EQUALITY2(up1->val, 1);
-    TEST_EQUALITY2(up2->val, 2);
-    TEST_EQUALITY2(up1.get_deleter().val, 1);
-    TEST_EQUALITY2(up2.get_deleter().val, 2);
+    TEST_EQUALITY(up1->val, 1);
+    TEST_EQUALITY(up2->val, 2);
+    TEST_EQUALITY(up1.get_deleter().val, 1);
+    TEST_EQUALITY(up2.get_deleter().val, 2);
     up1.swap(up2);
-    TEST_EQUALITY2(up1->val, 2);
-    TEST_EQUALITY2(up2->val, 1);
-    TEST_EQUALITY2(up1.get_deleter().val, 2);
-    TEST_EQUALITY2(up2.get_deleter().val, 1);
+    TEST_EQUALITY(up1->val, 2);
+    TEST_EQUALITY(up2->val, 1);
+    TEST_EQUALITY(up1.get_deleter().val, 2);
+    TEST_EQUALITY(up2.get_deleter().val, 1);
   }
-
-  // Success
-  return true;
 }
 
 TEUCHOS_UNIT_TEST( UniquePtr, std_unique_ptr_interface )
 {
-  TEST_ASSERT(test_unique_ptr_interface<std::unique_ptr>());
-  TEST_ASSERT(test_unique_ptr_interface<UniquePtr>());
+  test_unique_ptr_interface<std::unique_ptr>(out, success);
+  test_unique_ptr_interface<UniquePtr>(out, success);
   A *a;
   std::tuple<A*, std::default_delete<A>> t;
   int x = 5;

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -340,52 +340,52 @@ bool test_unique_ptr_interface()
   // Test 6
   flags = 0;
   D d;
-  if (flags != 1) return false;
+  TEST_EQUALITY2(flags, 1);
   {
     flags = 0;
     UPtr<Foo, D> up3(new Foo, d); // deleter copied
-    if (flags != 2) return false;
-    if (up3.get() == nullptr) return false;
+    TEST_EQUALITY2(flags, 2);
+    TEST_INEQUALITY2(up3.get(),  nullptr);
   }
   {
     flags = 0;
     UPtr<Foo, D&> up3b(new Foo, d); // up3b holds a reference to d
-    if (flags != 0) return false;
-    if (up3b.get() == nullptr) return false;
+    TEST_EQUALITY2(flags, 0);
+    TEST_INEQUALITY2(up3b.get(), nullptr);
   }
 
   // Test 7
   {
     flags = 0;
     UPtr<Foo, D> up4(new Foo, D()); // deleter moved
-    if (flags != 4) return false;
-    if (up4.get() == nullptr) return false;
+    TEST_EQUALITY2(flags, 4);
+    TEST_INEQUALITY2(up4.get(), nullptr);
   }
 
   // Test 8
   {
     UPtr<Foo> up5a(new Foo);
-    if (up5a.get() == nullptr) return false;
+    TEST_INEQUALITY2(up5a.get(), nullptr);
     UPtr<Foo> up5b(std::move(up5a)); // ownership transfer
-    if (up5a.get() != nullptr) return false;
-    if (up5b.get() == nullptr) return false;
+    TEST_EQUALITY2(up5a.get(), nullptr);
+    TEST_INEQUALITY2(up5b.get(), nullptr);
   }
 
   // Test 9
   {
     flags = 0;
     UPtr<Foo, D> up6a(new Foo, d); // D is copied
-    if (flags != 2) return false;
+    TEST_EQUALITY2(flags, 2);
     flags = 0;
     UPtr<Foo, D> up6b(std::move(up6a)); // D is moved
-    if (flags != 4) return false;
+    TEST_EQUALITY2(flags, 4);
 
     flags = 0;
     UPtr<Foo, D&> up6c(new Foo, d); // D is a reference
-    if (flags != 0) return false;
+    TEST_EQUALITY2(flags, 0);
     flags = 0;
     UPtr<Foo, D> up6d(std::move(up6c)); // D is copied
-    if (flags != 3) return false;
+    TEST_EQUALITY2(flags, 3);
   }
 
   // Test 10
@@ -405,7 +405,7 @@ bool test_unique_ptr_interface()
     UPtr<Foo, D> up2;
     flags = 0;
     up2 = std::move(up);
-    if (flags != 6) return false;
+    TEST_EQUALITY2(flags, 6);
   }
 
   // Test 12

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -87,10 +87,10 @@ TEUCHOS_UNIT_TEST( UniquePtr, assignSelf_null )
 TEUCHOS_UNIT_TEST( UniquePtr, assignSelf_nonnull )
 {
   UniquePtr<A> a_uniqueptr(new A);
-  A *a_raw_ptr = a_uniqueptr.get();
+  A *a_raw_ptr = a_uniqueptr.getRawPtr();
   a_uniqueptr = std::move(a_uniqueptr);
   TEST_ASSERT(nonnull(a_uniqueptr));
-  TEST_EQUALITY(a_uniqueptr.get(), a_raw_ptr);
+  TEST_EQUALITY(a_uniqueptr.getRawPtr(), a_raw_ptr);
 }
 
 #endif // HAVE_TEUCHOSCORE_CXX11

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -323,9 +323,9 @@ bool test_unique_ptr_interface()
 
   // Test 4
   UPtr<Foo> up1;
-  if (up1.get() != nullptr) return false;
+  TEST_ASSERT2(up1.get() == nullptr);
   UPtr<Foo> up1b(nullptr);
-  if (up1b.get() != nullptr) return false;
+  TEST_ASSERT2(up1b.get() == nullptr);
 
   // Test 5
   {

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -519,14 +519,21 @@ TEUCHOS_UNIT_TEST( UniquePtr, std_unique_ptr_interface )
   test_unique_ptr_interface<UniquePtr>(out, success);
   A *a;
   std::tuple<A*, std::default_delete<A>> t;
+  std::tuple<Ptr<A>, std::default_delete<A>, int> t2;
   int x = 5;
   auto del = [](int * p) { std::cout << "Deleting x, value is : " << *p; };
   std::unique_ptr<int, decltype(del)> px(&x, del);
   std::cout << "SIZE: " << sizeof(std::default_delete<A>) << std::endl;
   std::cout << "SIZE: " << sizeof(std::unique_ptr<A>) << std::endl;
+  std::cout << "SIZE: " << sizeof(UniquePtr<A>) << std::endl;
+  std::cout << "SIZE: " << sizeof(Ptr<A>) << std::endl;
   std::cout << "SIZE: " << sizeof(a) << std::endl;
   std::cout << "SIZE: " << sizeof(t) << std::endl;
+  std::cout << "SIZE: " << sizeof(t2) << std::endl;
   std::cout << "SIZE: " << sizeof(px) << std::endl;
+  std::cout << "XX: " << &std::get<0>(t2) << std::endl;
+  std::cout << "XX: " << &std::get<1>(t2) << std::endl;
+  std::cout << "XX: " << &std::get<2>(t2) << std::endl;
 }
 
 #endif // HAVE_TEUCHOSCORE_CXX11

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -316,10 +316,10 @@ bool test_unique_ptr_interface()
   int x2 = 5;
   auto del2 = [&deleted](int * p) { deleted = true; };
   {
-    if (deleted) return false;
+    TEST_ASSERT2(!deleted);
     UPtr<int, decltype(del2)> px2(&x2, del2);
   }
-  if (!deleted) return false;
+  TEST_ASSERT2(deleted);
 
   // Test 4
   UPtr<Foo> up1;
@@ -411,6 +411,13 @@ bool test_unique_ptr_interface()
     flags = 0;
     up2 = std::move(up);
     TEST_ASSERT2(flags == 5);
+  }
+
+  // Test 13
+  {
+    UPtr<Foo> up(new Foo());
+    up.reset();
+    TEST_ASSERT2(up.get() == nullptr);
   }
 
   // Success

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -285,6 +285,7 @@ void test_unique_ptr_interface()
 TEUCHOS_UNIT_TEST( UniquePtr, std_unique_ptr_interface )
 {
   test_unique_ptr_interface<std::unique_ptr>();
+  test_unique_ptr_interface<UniquePtr>();
 }
 
 #endif // HAVE_TEUCHOSCORE_CXX11

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -365,10 +365,16 @@ bool test_unique_ptr_interface()
 
   // Test 9
   {
+    flags = 0;
     UPtr<Foo, D> up6a(new Foo, d); // D is copied
+    if (flags != 2) return false;
+    flags = 0;
     UPtr<Foo, D> up6b(std::move(up6a)); // D is moved
+    if (flags != 4) return false;
 
+    flags = 0;
     UPtr<Foo, D&> up6c(new Foo, d); // D is a reference
+    if (flags != 0) return false;
     UPtr<Foo, D> up6d(std::move(up6c)); // D is copied
   }
 

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -126,6 +126,13 @@ TEUCHOS_UNIT_TEST( UniquePtr, reset_null2 )
   TEST_ASSERT(is_null(af_uptr));
 }
 
+TEUCHOS_UNIT_TEST( UniquePtr, dereference )
+{
+  UniquePtr<A> a_uptr = uniqueptr(new A);
+  TEST_ASSERT( (*a_uptr).A_f() == A_f_return );
+  TEST_ASSERT( a_uptr->A_f() == A_f_return );
+}
+
 TEUCHOS_UNIT_TEST( UniquePtr, danglingPtr1 )
 {
   ECHO(UniquePtr<A> a_uptr = uniqueptr(new A));

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -301,6 +301,12 @@ struct D { // deleter
   };
 };
 
+struct D2 { // deleter
+  D2(int _val) : val(_val) { };
+  void operator()(Foo2* p) const { delete p; };
+  int val;
+};
+
 // FIXME: Temporary macros --- we should figure out how to use TEST_ASSERT,
 // TEST_EQUALITY and TEST_INEQUALITY instead in the function below.
 #define TEST_ASSERT2(x) if (!(x)) return false
@@ -477,6 +483,21 @@ bool test_unique_ptr_interface()
     up1.swap(up2);
     TEST_EQUALITY2(up1->val, 2);
     TEST_EQUALITY2(up2->val, 1);
+  }
+
+  // Test 17
+  {
+    UPtr<Foo2, D2> up1(new Foo2(1), D2(1));
+    UPtr<Foo2, D2> up2(new Foo2(2), D2(2));
+    TEST_EQUALITY2(up1->val, 1);
+    TEST_EQUALITY2(up2->val, 2);
+    TEST_EQUALITY2(up1.get_deleter().val, 1);
+    TEST_EQUALITY2(up2.get_deleter().val, 2);
+    up1.swap(up2);
+    TEST_EQUALITY2(up1->val, 2);
+    TEST_EQUALITY2(up2->val, 1);
+    TEST_EQUALITY2(up1.get_deleter().val, 2);
+    TEST_EQUALITY2(up2.get_deleter().val, 1);
   }
 
   // Success

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -111,18 +111,22 @@ TEUCHOS_UNIT_TEST( UniquePtr, assign2 )
   UniquePtr<A> b_uptr;
   TEST_ASSERT(nonnull(a_uptr));
   TEST_ASSERT(is_null(b_uptr));
+  TEST_ASSERT( a_uptr->A_f() == A_f_return );
   b_uptr = std::move(a_uptr);
   TEST_ASSERT(nonnull(b_uptr));
   TEST_ASSERT(is_null(a_uptr));
+  TEST_ASSERT( b_uptr->A_f() == A_f_return );
 }
 
 TEUCHOS_UNIT_TEST( UniquePtr, assign3 )
 {
   UniquePtr<A> a_uptr(new A);
   TEST_ASSERT(nonnull(a_uptr));
+  TEST_ASSERT( a_uptr->A_f() == A_f_return );
   UniquePtr<A> b_uptr = std::move(a_uptr);
   TEST_ASSERT(nonnull(b_uptr));
   TEST_ASSERT(is_null(a_uptr));
+  TEST_ASSERT( b_uptr->A_f() == A_f_return );
 }
 
 TEUCHOS_UNIT_TEST( UniquePtr, getConst )

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -100,6 +100,12 @@ TEUCHOS_UNIT_TEST( UniquePtr, getConst )
   TEST_EQUALITY(a_uniqueptr.getRawPtr(), ca_ptr.getRawPtr());
 }
 
+TEUCHOS_UNIT_TEST( UniquePtr, explicit_null )
+{
+  UniquePtr<A> a_uptr(0);
+  TEST_ASSERT(is_null(a_uptr));
+}
+
 #endif // HAVE_TEUCHOSCORE_CXX11
 
 

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -116,6 +116,10 @@ TEUCHOS_UNIT_TEST( UniquePtr, assign2 )
   TEST_ASSERT(nonnull(b_uptr));
   TEST_ASSERT(is_null(a_uptr));
   TEST_ASSERT( b_uptr->A_f() == A_f_return );
+#ifdef TEUCHOS_DEBUG
+  TEST_THROW( *a_uptr, DanglingReferenceError );
+  TEST_THROW( a_uptr->A_f(), DanglingReferenceError );
+#endif
 }
 
 TEUCHOS_UNIT_TEST( UniquePtr, assign3 )

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -79,18 +79,18 @@ using Teuchos::RCPNodeTracer;
 
 TEUCHOS_UNIT_TEST( UniquePtr, assignSelf_null )
 {
-  UniquePtr<A> a_rcp;
-  a_rcp = std::move(a_rcp);
-  TEST_ASSERT(is_null(a_rcp));
+  UniquePtr<A> a_uniqueptr;
+  a_uniqueptr = std::move(a_uniqueptr);
+  TEST_ASSERT(is_null(a_uniqueptr));
 }
 
 TEUCHOS_UNIT_TEST( UniquePtr, assignSelf_nonnull )
 {
-  UniquePtr<A> a_rcp(new A);
-  A *a_raw_ptr = a_rcp.get();
-  a_rcp = std::move(a_rcp);
-  TEST_ASSERT(nonnull(a_rcp));
-  TEST_EQUALITY(a_rcp.get(), a_raw_ptr);
+  UniquePtr<A> a_uniqueptr(new A);
+  A *a_raw_ptr = a_uniqueptr.get();
+  a_uniqueptr = std::move(a_uniqueptr);
+  TEST_ASSERT(nonnull(a_uniqueptr));
+  TEST_EQUALITY(a_uniqueptr.get(), a_raw_ptr);
 }
 
 #endif // HAVE_TEUCHOSCORE_CXX11

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -294,6 +294,8 @@ struct D { // deleter
   };
 };
 
+#define TEST_ASSERT2(x) if (!(x)) return false
+
 template <template <typename T, typename Deleter=std::default_delete<T>> class UPtr>
 bool test_unique_ptr_interface()
 {
@@ -408,7 +410,7 @@ bool test_unique_ptr_interface()
     UPtr<Foo, D> up2;
     flags = 0;
     up2 = std::move(up);
-    if (flags != 5) return false;
+    TEST_ASSERT2(flags == 5);
   }
 
   // Success

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -93,6 +93,13 @@ TEUCHOS_UNIT_TEST( UniquePtr, assignSelf_nonnull )
   TEST_EQUALITY(a_uniqueptr.getRawPtr(), a_raw_ptr);
 }
 
+TEUCHOS_UNIT_TEST( UniquePtr, getConst )
+{
+  UniquePtr<A> a_uniqueptr(new A);
+  Ptr<const A> ca_ptr = a_uniqueptr.getConst();
+  TEST_EQUALITY(a_uniqueptr.getRawPtr(), ca_ptr.getRawPtr());
+}
+
 #endif // HAVE_TEUCHOSCORE_CXX11
 
 

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -286,6 +286,8 @@ struct D { // deleter
   D(const D&) { flags = 2; } // D copy ctor
   D(D&) { flags = 3; } // D non-const copy ctor
   D(D&&) { flags = 4; } // D move ctor
+  void operator=(D &d) { flags = 5; }
+  void operator=(D &&d) { flags = 6; }
   void operator()(Foo* p) const {
     // D is deleting a Foo TODO: test that it is called
     delete p;
@@ -389,6 +391,15 @@ bool test_unique_ptr_interface()
       return false;
     }
     delete fp;
+  }
+
+  // Test 11
+  {
+    UPtr<Foo, D> up(new Foo(), d);
+    UPtr<Foo, D> up2;
+    flags = 0;
+    up2 = std::move(up);
+    if (flags != 6) return false;
   }
 
   // Success

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -359,7 +359,7 @@ bool test_unique_ptr_interface()
     UPtr<Foo, D> up6b(std::move(up6a)); // D is moved
 
     UPtr<Foo, D&> up6c(new Foo, d); // D is a reference
-//    UPtr<Foo, D> up6d(std::move(up6c)); // D is copied
+    UPtr<Foo, D> up6d(std::move(up6c)); // D is copied
   }
 
   // Success

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -493,6 +493,24 @@ void test_unique_ptr_interface(Teuchos::FancyOStream &out, bool &success)
     TEST_EQUALITY(up1.get_deleter().val, 2);
     TEST_EQUALITY(up2.get_deleter().val, 1);
   }
+
+  // Test 18
+  {
+    UniquePtr<A> a_uptr1 = uniqueptr(new A);
+    UniquePtr<A> a_uptr2 = uniqueptr(new A);
+    int a_f_return1 = -1;
+    int a_f_return2 = -1;
+    UniquePtr<Get_A_f_return> af_uptr1 = uniqueptr(
+        new Get_A_f_return(a_uptr1.get(), &a_f_return1));
+    UniquePtr<Get_A_f_return> af_uptr2 = uniqueptr(
+        new Get_A_f_return(a_uptr2.get(), &a_f_return2));
+    TEST_INEQUALITY( a_f_return1, A_f_return );
+    TEST_INEQUALITY( a_f_return2, A_f_return );
+    af_uptr1 = std::move(af_uptr2);
+    TEST_EQUALITY( a_f_return1, A_f_return );
+    TEST_INEQUALITY( a_f_return2, A_f_return );
+    TEST_ASSERT(is_null(af_uptr2));
+  }
 }
 
 TEUCHOS_UNIT_TEST( UniquePtr, std_unique_ptr_interface )

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -420,7 +420,18 @@ bool test_unique_ptr_interface()
   // Test 13
   {
     UPtr<Foo> up(new Foo());
+    TEST_INEQUALITY2(up.get(), nullptr);
     up.reset();
+    TEST_EQUALITY2(up.get(), nullptr);
+  }
+
+  // Test 14
+  {
+    UPtr<Foo> up(new Foo());
+    TEST_INEQUALITY2(up.get(), nullptr);
+    up.reset(new Foo());
+    TEST_INEQUALITY2(up.get(), nullptr);
+    up.reset(nullptr);
     TEST_EQUALITY2(up.get(), nullptr);
   }
 

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -94,6 +94,37 @@ TEUCHOS_UNIT_TEST( UniquePtr, assignSelf_nonnull )
   TEST_EQUALITY(a_uptr.getRawPtr(), a_raw_ptr);
 }
 
+TEUCHOS_UNIT_TEST( UniquePtr, assign1 )
+{
+  UniquePtr<A> a_uptr;
+  UniquePtr<A> b_uptr;
+  TEST_ASSERT(is_null(a_uptr));
+  TEST_ASSERT(is_null(b_uptr));
+  b_uptr = std::move(a_uptr);
+  TEST_ASSERT(is_null(a_uptr));
+  TEST_ASSERT(is_null(b_uptr));
+}
+
+TEUCHOS_UNIT_TEST( UniquePtr, assign2 )
+{
+  UniquePtr<A> a_uptr(new A);
+  UniquePtr<A> b_uptr;
+  TEST_ASSERT(nonnull(a_uptr));
+  TEST_ASSERT(is_null(b_uptr));
+  b_uptr = std::move(a_uptr);
+  TEST_ASSERT(nonnull(b_uptr));
+  TEST_ASSERT(is_null(a_uptr));
+}
+
+TEUCHOS_UNIT_TEST( UniquePtr, assign3 )
+{
+  UniquePtr<A> a_uptr(new A);
+  TEST_ASSERT(nonnull(a_uptr));
+  UniquePtr<A> b_uptr = std::move(a_uptr);
+  TEST_ASSERT(nonnull(b_uptr));
+  TEST_ASSERT(is_null(a_uptr));
+}
+
 TEUCHOS_UNIT_TEST( UniquePtr, getConst )
 {
   UniquePtr<A> a_uptr(new A);

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -480,7 +480,12 @@ void test_unique_ptr_interface(Teuchos::FancyOStream &out, bool &success)
     flags = 0;
     flags2 = 0;
     up.reset(new Foo());
-//    TEST_EQUALITY(flags, 0); // Works in Release, fails in Debug mode
+#ifndef TEUCHOS_DEBUG
+    // Works in Release, fails in Debug mode, because we need to initialize the
+    // deallocator for RCP again in the reset() function. So we only test this
+    // in the Release mode.
+    TEST_EQUALITY(flags, 0);
+#endif
     TEST_EQUALITY(flags2, 7);
     TEST_INEQUALITY(up.get(), nullptr);
     flags2 = 0;

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -121,6 +121,24 @@ TEUCHOS_UNIT_TEST( UniquePtr, danglingPtr1 )
 #endif
 }
 
+TEUCHOS_UNIT_TEST( UniquePtr, danglingPtr2 )
+{
+  ECHO(Ptr<A> a_ptr);
+  ECHO(A *badPtr = 0);
+  {
+    ECHO(UniquePtr<A> a_uptr = uniqueptr(new A));
+    ECHO(badPtr = a_uptr.getRawPtr());
+    ECHO(a_ptr = a_uptr.ptr());
+    TEST_EQUALITY( a_ptr.getRawPtr(), badPtr );
+  }
+#ifdef TEUCHOS_DEBUG
+  TEST_THROW( *a_ptr, DanglingReferenceError );
+  (void)badPtr;
+#else
+  TEST_EQUALITY( a_ptr.getRawPtr(), badPtr );
+#endif
+}
+
 #endif // HAVE_TEUCHOSCORE_CXX11
 
 

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -525,9 +525,9 @@ void test_unique_ptr_interface(Teuchos::FancyOStream &out, bool &success)
     // size, as long as the deleter does not have any member variables.
     TEST_EQUALITY(sizeof(up1), sizeof(p));
     TEST_EQUALITY(sizeof(up2), sizeof(p));
-    TEST_ASSERT(sizeof(up3) > sizeof(p)); // D2 contains a member variable
     TEST_EQUALITY(sizeof(up4), sizeof(p));
 #endif
+    TEST_ASSERT(sizeof(up3) > sizeof(p)); // D2 contains a member variable
   }
 }
 

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -1,0 +1,89 @@
+/*
+// @HEADER
+// ***********************************************************************
+//
+//                    Teuchos: Common Tools Package
+//                 Copyright (2004) Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ***********************************************************************
+// @HEADER
+*/
+
+#include "TeuchosCore_ConfigDefs.hpp"
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_Ptr.hpp"
+#include "Teuchos_getConst.hpp"
+#include "TestClasses.hpp"
+
+
+namespace {
+
+
+using Teuchos::as;
+using Teuchos::null;
+using Teuchos::Ptr;
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcpFromRef;
+using Teuchos::rcpFromUndefRef;
+using Teuchos::outArg;
+using Teuchos::rcpWithEmbeddedObj;
+using Teuchos::getEmbeddedObj;
+using Teuchos::getOptionalEmbeddedObj;
+using Teuchos::getOptionalNonconstEmbeddedObj;
+using Teuchos::set_extra_data;
+using Teuchos::get_optional_nonconst_extra_data;
+using Teuchos::getConst;
+using Teuchos::NullReferenceError;
+using Teuchos::DanglingReferenceError;
+using Teuchos::DuplicateOwningRCPError;
+using Teuchos::RCP_STRONG;
+using Teuchos::RCP_WEAK;
+using Teuchos::RCPNodeTracer;
+
+#ifdef HAVE_TEUCHOSCORE_CXX11
+
+TEUCHOS_UNIT_TEST( UniquePtr, assignSelf_null )
+{
+  UniquePtr<A> a_rcp;
+  a_rcp = a_rcp;
+  TEST_ASSERT(is_null(a_rcp));
+}
+
+#endif // HAVE_TEUCHOSCORE_CXX11
+
+
+
+} // namespace

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -44,6 +44,7 @@
 #include "TeuchosCore_ConfigDefs.hpp"
 #include "Teuchos_UnitTestHarness.hpp"
 #include "Teuchos_Ptr.hpp"
+#include "Teuchos_UniquePtr.hpp"
 #include "Teuchos_getConst.hpp"
 #include "TestClasses.hpp"
 
@@ -54,6 +55,7 @@ namespace {
 using Teuchos::as;
 using Teuchos::null;
 using Teuchos::Ptr;
+using Teuchos::UniquePtr;
 using Teuchos::RCP;
 using Teuchos::rcp;
 using Teuchos::rcpFromRef;
@@ -78,7 +80,7 @@ using Teuchos::RCPNodeTracer;
 TEUCHOS_UNIT_TEST( UniquePtr, assignSelf_null )
 {
   UniquePtr<A> a_rcp;
-  a_rcp = a_rcp;
+  a_rcp = std::move(a_rcp);
   TEST_ASSERT(is_null(a_rcp));
 }
 

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -348,7 +348,9 @@ bool test_unique_ptr_interface()
 
   // Test 7
   {
+    flags = 0;
     UPtr<Foo, D> up4(new Foo, D()); // deleter moved
+    if (flags != 4) return false;
     if (up4.get() == nullptr) return false;
   }
 

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -279,7 +279,7 @@ struct Foo { // object to manage
   ~Foo() { } // ~Foo dtor TODO: test that it is called
 };
 
-int flags;
+int flags, flags2;
 
 struct D { // deleter
   D() { flags = 1; };
@@ -289,7 +289,8 @@ struct D { // deleter
   void operator=(D &d) { flags = 5; }
   void operator=(D &&d) { flags = 6; }
   void operator()(Foo* p) const {
-    // D is deleting a Foo TODO: test that it is called
+    // D is deleting a Foo
+    flags2 = 7;
     delete p;
   };
 };
@@ -437,11 +438,15 @@ bool test_unique_ptr_interface()
 
   // Test 15
   {
+    flags = 0;
     UPtr<Foo, D> up(new Foo(), D());
     TEST_EQUALITY2(flags, 4);
     TEST_INEQUALITY2(up.get(), nullptr);
+    flags = 0;
     up.reset(new Foo());
+    TEST_EQUALITY2(flags, 0);
     TEST_INEQUALITY2(up.get(), nullptr);
+    flags2 = 0;
     up.reset(nullptr);
     TEST_EQUALITY2(up.get(), nullptr);
   }

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -406,8 +406,10 @@ bool test_unique_ptr_interface()
   // Test 10
   {
     UPtr<Foo> up(new Foo());
+    TEST_ASSERT2(up);
     Foo *fp = up.release();
     TEST_EQUALITY2(up.get(), nullptr);
+    TEST_ASSERT2(!(up));
     TEST_INEQUALITY2(fp, nullptr);
     delete fp;
   }

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -126,6 +126,18 @@ TEUCHOS_UNIT_TEST( UniquePtr, reset_null2 )
   TEST_ASSERT(is_null(af_uptr));
 }
 
+TEUCHOS_UNIT_TEST( UniquePtr, deallocate )
+{
+  UniquePtr<A> a_uptr = uniqueptr(new A);
+  int a_f_return = -1;
+  {
+    UniquePtr<Get_A_f_return> af_uptr = uniqueptr(
+        new Get_A_f_return(a_uptr.get(), &a_f_return));
+    TEST_ASSERT( a_f_return != A_f_return );
+  }
+  TEST_ASSERT( a_f_return == A_f_return );
+}
+
 TEUCHOS_UNIT_TEST( UniquePtr, dereference )
 {
   UniquePtr<A> a_uptr = uniqueptr(new A);

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -435,6 +435,17 @@ bool test_unique_ptr_interface()
     TEST_EQUALITY2(up.get(), nullptr);
   }
 
+  // Test 15
+  {
+    UPtr<Foo, D> up(new Foo(), D());
+    TEST_EQUALITY2(flags, 4);
+    TEST_INEQUALITY2(up.get(), nullptr);
+    up.reset(new Foo());
+    TEST_INEQUALITY2(up.get(), nullptr);
+    up.reset(nullptr);
+    TEST_EQUALITY2(up.get(), nullptr);
+  }
+
   // Success
   return true;
 }

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -443,12 +443,15 @@ bool test_unique_ptr_interface()
     TEST_EQUALITY2(flags, 4);
     TEST_INEQUALITY2(up.get(), nullptr);
     flags = 0;
+    flags2 = 0;
     up.reset(new Foo());
-    TEST_EQUALITY2(flags, 0);
+//    TEST_EQUALITY2(flags, 0);
+    TEST_EQUALITY2(flags2, 7);
     TEST_INEQUALITY2(up.get(), nullptr);
     flags2 = 0;
     up.reset(nullptr);
     TEST_EQUALITY2(up.get(), nullptr);
+    TEST_EQUALITY2(flags2, 7);
   }
 
   // Success

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -362,6 +362,17 @@ bool test_unique_ptr_interface()
     UPtr<Foo, D> up6d(std::move(up6c)); // D is copied
   }
 
+  // Test 10
+  {
+    UPtr<Foo> up(new Foo());
+    Foo *fp = up.release();
+    if (up.get() != nullptr) {
+      delete fp;
+      return false;
+    }
+    delete fp;
+  }
+
   // Success
   return true;
 }

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -114,6 +114,18 @@ TEUCHOS_UNIT_TEST( UniquePtr, reset_null )
   TEST_ASSERT(is_null(a_uptr));
 }
 
+TEUCHOS_UNIT_TEST( UniquePtr, reset_null2 )
+{
+  UniquePtr<A> a_uptr = uniqueptr(new A);
+  int a_f_return = -1;
+  UniquePtr<Get_A_f_return> af_uptr = uniqueptr(new Get_A_f_return(a_uptr.get(),
+        &a_f_return));
+  TEST_ASSERT( a_f_return != A_f_return );
+  af_uptr.reset();
+  TEST_ASSERT( a_f_return == A_f_return );
+  TEST_ASSERT(is_null(af_uptr));
+}
+
 TEUCHOS_UNIT_TEST( UniquePtr, danglingPtr1 )
 {
   ECHO(UniquePtr<A> a_uptr = uniqueptr(new A));

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -286,6 +286,12 @@ TEUCHOS_UNIT_TEST( UniquePtr, std_unique_ptr_interface )
 {
   test_unique_ptr_interface<std::unique_ptr>();
   test_unique_ptr_interface<UniquePtr>();
+  A *a;
+  std::tuple<A*, std::default_delete<A>> t;
+  std::cout << "SIZE: " << sizeof(std::default_delete<A>) << std::endl;
+  std::cout << "SIZE: " << sizeof(std::unique_ptr<A>) << std::endl;
+  std::cout << "SIZE: " << sizeof(a) << std::endl;
+  std::cout << "SIZE: " << sizeof(t) << std::endl;
 }
 
 #endif // HAVE_TEUCHOSCORE_CXX11

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -279,11 +279,13 @@ struct Foo { // object to manage
   ~Foo() { } // ~Foo dtor TODO: test that it is called
 };
 
+int flags;
+
 struct D { // deleter
-  D() {}; // TODO: test that it is called
-  D(const D&) { } // D copy ctor TODO: test that it is called
-  D(D&) { } // D non-const copy ctor TODO: test that it is called
-  D(D&&) { } // D move ctor TODO: test that it is called
+  D() { flags = 1; };
+  D(const D&) { flags = 2; } // D copy ctor
+  D(D&) { flags = 3; } // D non-const copy ctor
+  D(D&&) { flags = 4; } // D move ctor
   void operator()(Foo* p) const {
     // D is deleting a Foo TODO: test that it is called
     delete p;
@@ -328,13 +330,19 @@ bool test_unique_ptr_interface()
   }
 
   // Test 6
+  flags = 0;
   D d;
+  if (flags != 1) return false;
   {
+    flags = 0;
     UPtr<Foo, D> up3(new Foo, d); // deleter copied
+    if (flags != 2) return false;
     if (up3.get() == nullptr) return false;
   }
   {
+    flags = 0;
     UPtr<Foo, D&> up3b(new Foo, d); // up3b holds a reference to d
+    if (flags != 0) return false;
     if (up3b.get() == nullptr) return false;
   }
 

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -375,7 +375,9 @@ bool test_unique_ptr_interface()
     flags = 0;
     UPtr<Foo, D&> up6c(new Foo, d); // D is a reference
     if (flags != 0) return false;
+    flags = 0;
     UPtr<Foo, D> up6d(std::move(up6c)); // D is copied
+    if (flags != 3) return false;
   }
 
   // Test 10

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -83,6 +83,7 @@ TEUCHOS_UNIT_TEST( UniquePtr, assignSelf_null )
   UniquePtr<A> a_uptr;
   a_uptr = std::move(a_uptr);
   TEST_ASSERT(is_null(a_uptr));
+  TEST_ASSERT(a_uptr.is_null());
 }
 
 TEUCHOS_UNIT_TEST( UniquePtr, assignSelf_nonnull )
@@ -91,6 +92,7 @@ TEUCHOS_UNIT_TEST( UniquePtr, assignSelf_nonnull )
   A *a_raw_ptr = a_uptr.getRawPtr();
   a_uptr = std::move(a_uptr);
   TEST_ASSERT(nonnull(a_uptr));
+  TEST_ASSERT(!a_uptr.is_null());
   TEST_EQUALITY(a_uptr.getRawPtr(), a_raw_ptr);
 }
 
@@ -110,6 +112,7 @@ TEUCHOS_UNIT_TEST( UniquePtr, assign2 )
   UniquePtr<A> a_uptr(new A);
   UniquePtr<A> b_uptr;
   TEST_ASSERT(nonnull(a_uptr));
+  TEST_ASSERT(!a_uptr.is_null());
   TEST_ASSERT(is_null(b_uptr));
   TEST_EQUALITY( a_uptr->A_f(), A_f_return );
   b_uptr = std::move(a_uptr);
@@ -223,6 +226,24 @@ TEUCHOS_UNIT_TEST( UniquePtr, danglingPtr2 )
     ECHO(UniquePtr<A> a_uptr = uniqueptr(new A));
     ECHO(badPtr = a_uptr.getRawPtr());
     ECHO(a_ptr = a_uptr.ptr());
+    TEST_EQUALITY( a_ptr.getRawPtr(), badPtr );
+  }
+#ifdef TEUCHOS_DEBUG
+  TEST_THROW( *a_ptr, DanglingReferenceError );
+  (void)badPtr;
+#else
+  TEST_EQUALITY( a_ptr.getRawPtr(), badPtr );
+#endif
+}
+
+TEUCHOS_UNIT_TEST( UniquePtr, danglingPtr2b )
+{
+  ECHO(Ptr<A> a_ptr);
+  ECHO(A *badPtr = 0);
+  {
+    ECHO(UniquePtr<A> a_uptr = uniqueptr(new A));
+    ECHO(badPtr = a_uptr.getRawPtr());
+    ECHO(a_ptr = a_uptr());
     TEST_EQUALITY( a_ptr.getRawPtr(), badPtr );
   }
 #ifdef TEUCHOS_DEBUG

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -273,19 +273,20 @@ TEUCHOS_UNIT_TEST( UniquePtr, danglingPtr4 )
 }
 
 template <template <typename T, typename Deleter=std::default_delete<T>> class UPtr>
-void test_unique_ptr_interface()
+bool test_unique_ptr_interface()
 {
   UPtr<A> p1(new A);
   {
     UPtr<A> p2(std::move(p1));
     p1 = std::move(p2);
   }
+  return true;
 }
 
 TEUCHOS_UNIT_TEST( UniquePtr, std_unique_ptr_interface )
 {
-  test_unique_ptr_interface<std::unique_ptr>();
-  test_unique_ptr_interface<UniquePtr>();
+  TEST_ASSERT(test_unique_ptr_interface<std::unique_ptr>());
+  TEST_ASSERT(test_unique_ptr_interface<UniquePtr>());
   A *a;
   std::tuple<A*, std::default_delete<A>> t;
   int x = 5;

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -111,11 +111,11 @@ TEUCHOS_UNIT_TEST( UniquePtr, assign2 )
   UniquePtr<A> b_uptr;
   TEST_ASSERT(nonnull(a_uptr));
   TEST_ASSERT(is_null(b_uptr));
-  TEST_ASSERT( a_uptr->A_f() == A_f_return );
+  TEST_EQUALITY( a_uptr->A_f(), A_f_return );
   b_uptr = std::move(a_uptr);
   TEST_ASSERT(nonnull(b_uptr));
   TEST_ASSERT(is_null(a_uptr));
-  TEST_ASSERT( b_uptr->A_f() == A_f_return );
+  TEST_EQUALITY( b_uptr->A_f(), A_f_return );
 #ifdef TEUCHOS_DEBUG
   TEST_THROW( *a_uptr, DanglingReferenceError );
   TEST_THROW( a_uptr->A_f(), DanglingReferenceError );
@@ -126,11 +126,11 @@ TEUCHOS_UNIT_TEST( UniquePtr, assign3 )
 {
   UniquePtr<A> a_uptr(new A);
   TEST_ASSERT(nonnull(a_uptr));
-  TEST_ASSERT( a_uptr->A_f() == A_f_return );
+  TEST_EQUALITY( a_uptr->A_f(), A_f_return );
   UniquePtr<A> b_uptr = std::move(a_uptr);
   TEST_ASSERT(nonnull(b_uptr));
   TEST_ASSERT(is_null(a_uptr));
-  TEST_ASSERT( b_uptr->A_f() == A_f_return );
+  TEST_EQUALITY( b_uptr->A_f(), A_f_return );
 #ifdef TEUCHOS_DEBUG
   TEST_THROW( *a_uptr, DanglingReferenceError );
   TEST_THROW( a_uptr->A_f(), DanglingReferenceError );
@@ -147,7 +147,7 @@ TEUCHOS_UNIT_TEST( UniquePtr, assign4 )
 #ifdef TEUCHOS_DEBUG
   TEST_THROW( t = (*orig == 5), DanglingReferenceError );
 #endif
-  TEST_ASSERT(*stolen == 5);
+  TEST_EQUALITY(*stolen, 5);
 }
 
 TEUCHOS_UNIT_TEST( UniquePtr, getConst )
@@ -176,9 +176,9 @@ TEUCHOS_UNIT_TEST( UniquePtr, reset_null2 )
   int a_f_return = -1;
   UniquePtr<Get_A_f_return> af_uptr = uniqueptr(new Get_A_f_return(a_uptr.get(),
         &a_f_return));
-  TEST_ASSERT( a_f_return != A_f_return );
+  TEST_INEQUALITY( a_f_return, A_f_return );
   af_uptr.reset();
-  TEST_ASSERT( a_f_return == A_f_return );
+  TEST_EQUALITY( a_f_return, A_f_return );
   TEST_ASSERT(is_null(af_uptr));
 }
 
@@ -189,16 +189,16 @@ TEUCHOS_UNIT_TEST( UniquePtr, deallocate )
   {
     UniquePtr<Get_A_f_return> af_uptr = uniqueptr(
         new Get_A_f_return(a_uptr.get(), &a_f_return));
-    TEST_ASSERT( a_f_return != A_f_return );
+    TEST_INEQUALITY( a_f_return, A_f_return );
   }
-  TEST_ASSERT( a_f_return == A_f_return );
+  TEST_EQUALITY( a_f_return, A_f_return );
 }
 
 TEUCHOS_UNIT_TEST( UniquePtr, dereference )
 {
   UniquePtr<A> a_uptr = uniqueptr(new A);
-  TEST_ASSERT( (*a_uptr).A_f() == A_f_return );
-  TEST_ASSERT( a_uptr->A_f() == A_f_return );
+  TEST_EQUALITY( (*a_uptr).A_f(), A_f_return );
+  TEST_EQUALITY( a_uptr->A_f(), A_f_return );
 }
 
 TEUCHOS_UNIT_TEST( UniquePtr, danglingPtr1 )

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -393,10 +393,8 @@ bool test_unique_ptr_interface()
   {
     UPtr<Foo> up(new Foo());
     Foo *fp = up.release();
-    if (up.get() != nullptr) {
-      delete fp;
-      return false;
-    }
+    TEST_EQUALITY2(up.get(), nullptr);
+    TEST_INEQUALITY2(fp, nullptr);
     delete fp;
   }
 

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -272,6 +272,21 @@ TEUCHOS_UNIT_TEST( UniquePtr, danglingPtr4 )
 #endif
 }
 
+template <template <typename T, typename Deleter=std::default_delete<T>> class UPtr>
+void test_unique_ptr_interface()
+{
+  UPtr<A> p1(new A);
+  {
+    UPtr<A> p2(std::move(p1));
+    p1 = std::move(p2);
+  }
+}
+
+TEUCHOS_UNIT_TEST( UniquePtr, std_unique_ptr_interface )
+{
+  test_unique_ptr_interface<std::unique_ptr>();
+}
+
 #endif // HAVE_TEUCHOSCORE_CXX11
 
 

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -294,10 +294,11 @@ struct D { // deleter
   };
 };
 
-// FIXME: Temporary macros --- we should figure out how to use TEST_ASSERT and
-// TEST_EQUALITY instead in the function below.
+// FIXME: Temporary macros --- we should figure out how to use TEST_ASSERT,
+// TEST_EQUALITY and TEST_INEQUALITY instead in the function below.
 #define TEST_ASSERT2(x) if (!(x)) return false
 #define TEST_EQUALITY2(a, b) TEST_ASSERT2((a) == (b))
+#define TEST_INEQUALITY2(a, b) TEST_ASSERT2((a) != (b))
 
 template <template <typename T, typename Deleter=std::default_delete<T>> class UPtr>
 bool test_unique_ptr_interface()
@@ -333,7 +334,7 @@ bool test_unique_ptr_interface()
   // Test 5
   {
     UPtr<Foo> up2(new Foo);
-    if (up2.get() == nullptr) return false;
+    TEST_INEQUALITY2(up2.get(), nullptr);
   }
 
   // Test 6

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -107,6 +107,13 @@ TEUCHOS_UNIT_TEST( UniquePtr, explicit_null )
   TEST_ASSERT(is_null(a_uptr));
 }
 
+TEUCHOS_UNIT_TEST( UniquePtr, reset_null )
+{
+  UniquePtr<A> a_uptr = uniqueptr(new A);
+  a_uptr.reset();
+  TEST_ASSERT(is_null(a_uptr));
+}
+
 TEUCHOS_UNIT_TEST( UniquePtr, danglingPtr1 )
 {
   ECHO(UniquePtr<A> a_uptr = uniqueptr(new A));

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -137,6 +137,19 @@ TEUCHOS_UNIT_TEST( UniquePtr, assign3 )
 #endif
 }
 
+TEUCHOS_UNIT_TEST( UniquePtr, assign4 )
+{
+  UniquePtr<int> orig(new int(5));
+  bool t;
+  t = (*orig == 5);
+  TEST_ASSERT(t)
+  auto stolen = std::move(orig);
+#ifdef TEUCHOS_DEBUG
+  TEST_THROW( t = (*orig == 5), DanglingReferenceError );
+#endif
+  TEST_ASSERT(*stolen == 5);
+}
+
 TEUCHOS_UNIT_TEST( UniquePtr, getConst )
 {
   UniquePtr<A> a_uptr(new A);

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -511,6 +511,24 @@ void test_unique_ptr_interface(Teuchos::FancyOStream &out, bool &success)
     TEST_INEQUALITY( a_f_return2, A_f_return );
     TEST_ASSERT(is_null(af_uptr2));
   }
+
+  // Test 19
+  {
+    Foo *p;
+    UPtr<Foo> up1(new Foo());
+    UPtr<Foo, D> up2(new Foo(), D());
+    UPtr<Foo2, D2> up3(new Foo2(1), D2(1));
+    auto del = [](Foo *p_) { std::cout << "Deleting Foo"; };
+    UPtr<Foo, decltype(del)> up4(new Foo(), del);
+#ifndef TEUCHOS_DEBUG
+    // In Release mode, the size of UniquePtr must be equal to the raw pointer
+    // size, as long as the deleter does not have any member variables.
+    TEST_EQUALITY(sizeof(up1), sizeof(p));
+    TEST_EQUALITY(sizeof(up2), sizeof(p));
+    TEST_ASSERT(sizeof(up3) > sizeof(p)); // D2 contains a member variable
+    TEST_EQUALITY(sizeof(up4), sizeof(p));
+#endif
+  }
 }
 
 TEUCHOS_UNIT_TEST( UniquePtr, std_unique_ptr_interface )

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -131,6 +131,10 @@ TEUCHOS_UNIT_TEST( UniquePtr, assign3 )
   TEST_ASSERT(nonnull(b_uptr));
   TEST_ASSERT(is_null(a_uptr));
   TEST_ASSERT( b_uptr->A_f() == A_f_return );
+#ifdef TEUCHOS_DEBUG
+  TEST_THROW( *a_uptr, DanglingReferenceError );
+  TEST_THROW( a_uptr->A_f(), DanglingReferenceError );
+#endif
 }
 
 TEUCHOS_UNIT_TEST( UniquePtr, getConst )

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -56,6 +56,7 @@ using Teuchos::as;
 using Teuchos::null;
 using Teuchos::Ptr;
 using Teuchos::UniquePtr;
+using Teuchos::uniqueptr;
 using Teuchos::RCP;
 using Teuchos::rcp;
 using Teuchos::rcpFromRef;
@@ -79,31 +80,45 @@ using Teuchos::RCPNodeTracer;
 
 TEUCHOS_UNIT_TEST( UniquePtr, assignSelf_null )
 {
-  UniquePtr<A> a_uniqueptr;
-  a_uniqueptr = std::move(a_uniqueptr);
-  TEST_ASSERT(is_null(a_uniqueptr));
+  UniquePtr<A> a_uptr;
+  a_uptr = std::move(a_uptr);
+  TEST_ASSERT(is_null(a_uptr));
 }
 
 TEUCHOS_UNIT_TEST( UniquePtr, assignSelf_nonnull )
 {
-  UniquePtr<A> a_uniqueptr(new A);
-  A *a_raw_ptr = a_uniqueptr.getRawPtr();
-  a_uniqueptr = std::move(a_uniqueptr);
-  TEST_ASSERT(nonnull(a_uniqueptr));
-  TEST_EQUALITY(a_uniqueptr.getRawPtr(), a_raw_ptr);
+  UniquePtr<A> a_uptr(new A);
+  A *a_raw_ptr = a_uptr.getRawPtr();
+  a_uptr = std::move(a_uptr);
+  TEST_ASSERT(nonnull(a_uptr));
+  TEST_EQUALITY(a_uptr.getRawPtr(), a_raw_ptr);
 }
 
 TEUCHOS_UNIT_TEST( UniquePtr, getConst )
 {
-  UniquePtr<A> a_uniqueptr(new A);
-  Ptr<const A> ca_ptr = a_uniqueptr.getConst();
-  TEST_EQUALITY(a_uniqueptr.getRawPtr(), ca_ptr.getRawPtr());
+  UniquePtr<A> a_uptr(new A);
+  Ptr<const A> ca_ptr = a_uptr.getConst();
+  TEST_EQUALITY(a_uptr.getRawPtr(), ca_ptr.getRawPtr());
 }
 
 TEUCHOS_UNIT_TEST( UniquePtr, explicit_null )
 {
   UniquePtr<A> a_uptr(0);
   TEST_ASSERT(is_null(a_uptr));
+}
+
+TEUCHOS_UNIT_TEST( UniquePtr, danglingPtr1 )
+{
+  ECHO(UniquePtr<A> a_uptr = uniqueptr(new A));
+  ECHO(Ptr<A> a_ptr = a_uptr.ptr());
+  ECHO(A *badPtr = a_uptr.getRawPtr());
+  ECHO(a_uptr = null);
+#ifdef TEUCHOS_DEBUG
+  TEST_THROW( *a_ptr, DanglingReferenceError );
+  (void)badPtr;
+#else
+  TEST_EQUALITY( a_ptr.getRawPtr(), badPtr );
+#endif
 }
 
 #endif // HAVE_TEUCHOSCORE_CXX11

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -284,8 +284,18 @@ bool test_unique_ptr_interface()
 
   // Test 2
   int x = 5;
-  auto del = [](int * p) { std::cout << "Deleting x, value is : " << *p; };
-  UPtr<int, decltype(del)> px(&x, del);
+  auto del1 = [](int * p) { std::cout << "Deleting x, value is : " << *p << std::endl; };
+  UPtr<int, decltype(del1)> px1(&x, del1);
+
+  // Test 3
+  bool deleted = false;
+  int x2 = 5;
+  auto del2 = [&deleted](int * p) { deleted = true; };
+  {
+    if (deleted) return false;
+    UPtr<int, decltype(del2)> px2(&x2, del2);
+  }
+  if (!deleted) return false;
 
   // Success
   return true;

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -445,7 +445,7 @@ bool test_unique_ptr_interface()
     flags = 0;
     flags2 = 0;
     up.reset(new Foo());
-//    TEST_EQUALITY2(flags, 0);
+//    TEST_EQUALITY2(flags, 0); // Works in Release, fails in Debug mode
     TEST_EQUALITY2(flags2, 7);
     TEST_INEQUALITY2(up.get(), nullptr);
     flags2 = 0;

--- a/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/UniquePtr_UnitTests.cpp
@@ -288,10 +288,14 @@ TEUCHOS_UNIT_TEST( UniquePtr, std_unique_ptr_interface )
   test_unique_ptr_interface<UniquePtr>();
   A *a;
   std::tuple<A*, std::default_delete<A>> t;
+  int x = 5;
+  auto del = [](int * p) { std::cout << "Deleting x, value is : " << *p; };
+  std::unique_ptr<int, decltype(del)> px(&x, del);
   std::cout << "SIZE: " << sizeof(std::default_delete<A>) << std::endl;
   std::cout << "SIZE: " << sizeof(std::unique_ptr<A>) << std::endl;
   std::cout << "SIZE: " << sizeof(a) << std::endl;
   std::cout << "SIZE: " << sizeof(t) << std::endl;
+  std::cout << "SIZE: " << sizeof(px) << std::endl;
 }
 
 #endif // HAVE_TEUCHOSCORE_CXX11


### PR DESCRIPTION
This is a work in progress. I will keep pushing more patches as I implement things, and at the very end I will rebase and create a few very nice patches.

TODO:
- [x] Implement a custom deallocator (follow similar design as `std::unique_ptr`, i.e. add a template parameter, but unlike `std::unique_ptr` specialize the template for the most common default case for efficiency -- `std::unique_ptr` uses a tuple to store both the pointer and the deallocator)
- [x] Use a tuple to store both the pointer and the deallocator
- [x] Test that the Release mode `sizeof` UniquePtr is the same as raw pointer, as long as the deallocator doesn't have any member variables
- [x] Test that proper deleter constructors are called
- [x] Add the rest of the methods from `RCP` (appropriately adapted to `UniquePtr`)
- [x] Make sure we have the same interface as `std::unique_ptr`, or as close as possible
- [ ] Doxygen documentation: the class UniquePtr will need Doxygen documentation before the final version gets pushed to Trilinos
- [x] Separate out function implementation bodies from C++ class body
- [x] `UniquePtr::operator=()` should release the old object first, so `std::swap` is not the way to go (write a test first that fails, then fix it)
- [x] Test that `UniquePtr::swap()` swaps the deleter as well
- [x] Achieve 100% test coverage. Done --- each line is now tested. From now on, always add the test first, then implement it, to ensure that every line is tested.
